### PR TITLE
Fix YouTube video, channel fetch

### DIFF
--- a/app/Helpers/aggro_helper.php
+++ b/app/Helpers/aggro_helper.php
@@ -259,6 +259,8 @@ if (!function_exists('fetch_url')) {
     curl_setopt($fetch, CURLOPT_USERAGENT, $agent);
     curl_setopt($fetch, CURLOPT_CONNECTTIMEOUT, 20);
     curl_setopt($fetch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($fetch, CURLOPT_FOLLOWLOCATION, TRUE);
+    curl_setopt($fetch, CURLOPT_MAXREDIRS, 4);
     $response = curl_exec($fetch);
     $httpCode = curl_getinfo($fetch, CURLINFO_HTTP_CODE);
     $errorInfo = curl_error($fetch);

--- a/app/Helpers/youtube_helper.php
+++ b/app/Helpers/youtube_helper.php
@@ -74,12 +74,10 @@ if (!function_exists('youtube_get_video_source')) {
     }
 
     $channelResult = fetch_url($channelURL, 'text', 1);
-    preg_match_all($canonicalRegex, $channelResult, $matches, PREG_PATTERN_ORDER);
+    preg_match($canonicalRegex, $channelResult, $matches);
 
     if ($matches[1]) {
-      if ($matches[1][0]) {
-        return $matches[1][0];
-      }
+      return $matches[1];
     }
 
     return FALSE;

--- a/app/Helpers/youtube_helper.php
+++ b/app/Helpers/youtube_helper.php
@@ -67,7 +67,7 @@ if (!function_exists('youtube_get_video_source')) {
       return FALSE;
     }
 
-    $channelURL = $result->author_url->asXML();
+    $channelURL = strval($result->author_url);
 
     if (substr(str_replace('https://www.youtube.com/channel/', '', $channelURL), 0, 2) == "UC") {
       return str_replace('https://www.youtube.com/channel/', '', $channelURL);


### PR DESCRIPTION
Lack of cURL option meant 302 response was a stopping point.

Fixes pass thru by converting XML object to string with proper function.

Makes pattern match logic less clunky.