### PR TITLE
Hotfix/youtube oembed check

### DIFF
--- a/app/Helpers/youtube_helper.php
+++ b/app/Helpers/youtube_helper.php
@@ -158,8 +158,8 @@ if (!function_exists('youtube_parse_meta')) {
 
     $oEmbed = "https://www.youtube.com/oembed?format=xml&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D" . $video['video_id'];
     $result = fetch_url($oEmbed, 'simplexml', 1);
-    $video['video_width'] = 600;
-    $video['video_height'] = 338;
+    $video['video_width'] = 800;
+    $video['video_height'] = 450;
     if ($result !== FALSE) {
       $video['video_width'] = $result->width;
       $video['video_height'] = $result->height;

--- a/app/Helpers/youtube_helper.php
+++ b/app/Helpers/youtube_helper.php
@@ -158,10 +158,11 @@ if (!function_exists('youtube_parse_meta')) {
 
     $oEmbed = "https://www.youtube.com/oembed?format=xml&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D" . $video['video_id'];
     $result = fetch_url($oEmbed, 'simplexml', 1);
-    $video['video_width'] = $result->width;
-    $video['video_height'] = $result->height;
-    $video['video_aspect_ratio'] = round($result->width / $result->height, 3);
-
+    if ($result->width && $result->height) {
+      $video['video_width'] = $result->width;
+      $video['video_height'] = $result->height;
+      $video['video_aspect_ratio'] = round($result->width / $result->height, 3);
+    }
     return $video;
   }
 

--- a/app/Helpers/youtube_helper.php
+++ b/app/Helpers/youtube_helper.php
@@ -158,11 +158,13 @@ if (!function_exists('youtube_parse_meta')) {
 
     $oEmbed = "https://www.youtube.com/oembed?format=xml&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D" . $video['video_id'];
     $result = fetch_url($oEmbed, 'simplexml', 1);
-    if ($result->width && $result->height) {
+    $video['video_width'] = 600;
+    $video['video_height'] = 338;
+    if ($result !== FALSE) {
       $video['video_width'] = $result->width;
       $video['video_height'] = $result->height;
-      $video['video_aspect_ratio'] = round($result->width / $result->height, 3);
     }
+    $video['video_aspect_ratio'] = round($video['video_width'] / $video['video_height'], 3);
     return $video;
   }
 


### PR DESCRIPTION
When trying to add a video via shortcut, I saw a divide by 0 error in the youtube helper.

Now that invalid XML in URL fetches returns false (in #288), I needed to account for that outcome in video saves. This sets a default video width and height.