### PR TITLE
.test → .docksal.site for local domain

### DIFF
--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -1,4 +1,4 @@
 DOCKSAL_STACK=default
 CLI_IMAGE='docksal/cli:php8.0-3'
 DOCROOT=public
-VIRTUAL_HOST=aggro.test
+VIRTUAL_HOST=aggro.docksal.site

--- a/.env-sample
+++ b/.env-sample
@@ -8,7 +8,7 @@ CI_ENVIRONMENT=development
 # APP
 #--------------------------------------------------------------------
 
-app.baseURL='http://aggro.test'
+app.baseURL='http://aggro.docksal.site'
 
 #--------------------------------------------------------------------
 # DATABASE

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Aggro uses [Docksal](https://docksal.io) for local development.
 1. Install Docksal <https://docksal.io/installation>
 2. `git clone https://github.com/jsnmrs/aggro.git && cd aggro`
 3. `fin init`
-5. Open <http://aggro.test>
+5. Open <http://aggro.docksal.site>


### PR DESCRIPTION
Based on https://github.com/docksal/docksal/issues/1215, https://github.com/docksal/docksal/issues/1517, and the deprecation notice I saw in https://github.com/docksal/docksal/releases/tag/v1.17.0