### PR TITLE
Docksal uses LTS, which is good enough

### DIFF
--- a/.docksal/commands/init-site
+++ b/.docksal/commands/init-site
@@ -32,17 +32,8 @@ source ~/.bashrc
 # shellcheck source=/dev/null
 source ~/.nvm/nvm.sh
 
-echo 'Download Node.js 16.x'
-nvm install 16
-
-# Check which Node.js versions are installed and show defaults.
-echo 'Here are the current Node.js versions installed'
-nvm ls
-
-# set the global version of Node.js being used.
-echo 'Set the default version of Node.js to 16.x'
-nvm use 16
-nvm alias default 16
+# Print Node version and location
+which node
 
 # Install NPM dependencies
 npm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
           cache: "npm"
       - name: Process and lint
         run: |

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -1,0 +1,19 @@
+name: Test NPM build
+
+on:
+  workflow_dispatch: # enable run button on github.com
+  pull_request:
+
+jobs:
+  build-npm:
+    name: Run NPM build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: "npm"
+      - name: Process and lint
+        run: |
+          npm install
+          npm run build

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -15,5 +15,7 @@ jobs:
           cache: "npm"
       - name: Process and lint
         run: |
+          node -v
+          npm -v
           npm install
           npm run build


### PR DESCRIPTION
Instead of pulling in a specific version of Node, just run LTS in Docksal.

Also missed an opportunity to have an untested NPM build deployed to production! One more PR test to avoid that issue.