### PR TITLE
Specific path to PHP bin

### DIFF
--- a/.crontab
+++ b/.crontab
@@ -8,7 +8,7 @@ MAILTO=""
 
 ## aggro cron
 
-PHP_PATH='/usr/bin/php'
+PHP_PATH='/usr/local/php80/bin/php'
 INDEX_PATH='/home/bmxfeed/aggro/current/public/index.php'
 
 ## aggro news


### PR DESCRIPTION
I thought a less specific PHP bin path would be an improvement in #326, but it's defaulting to PHP 7.4. This calls the PHP 8.0 bin specifically. I'll bump this to 8.1 shortly.