### PR TITLE
Stylelint a11y

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,4 @@
 # Browsers that we support
 # run `npx browserslist` in this directory to see list
 
-defaults and > .5% in US, IE 11
+defaults and > .5% in US

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,6 +1,7 @@
 {
   "extends": ["stylelint-config-standard-scss"],
   "plugins": [
+    "@double-great/stylelint-a11y",
     "stylelint-declaration-block-no-ignored-properties",
     "stylelint-declaration-strict-value",
     "stylelint-no-unsupported-browser-features",
@@ -149,6 +150,14 @@
     "value-list-comma-space-after": "always-single-line",
     "value-list-comma-space-before": "never",
     "value-no-vendor-prefix": true,
+
+    "a11y/no-outline-none": true,
+    "a11y/selector-pseudo-class-focus": true,
+    "a11y/font-size-is-readable": [true, { "severity": "warning" }],
+    "a11y/no-spread-text": [true, { "severity": "warning" }],
+    "a11y/no-obsolete-attribute": [true, { "severity": "warning" }],
+    "a11y/no-obsolete-element": [true, { "severity": "warning" }],
+    "a11y/no-text-align-justify": [true, { "severity": "error" }],
 
     "plugin/declaration-block-no-ignored-properties": true,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001341",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
-      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
+      "version": "1.0.30001354",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001354.tgz",
+      "integrity": "sha512-mImKeCkyGDAHNywYFA4bqnLAzTUvVkqPvhY4DV47X+Gl2c5Z8c3KNETnXp14GQt11LvxE8AwjzGxJ+rsikiOzg==",
       "dev": true,
       "funding": [
         {
@@ -3971,9 +3971,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001341",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
-      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
+      "version": "1.0.30001354",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001354.tgz",
+      "integrity": "sha512-mImKeCkyGDAHNywYFA4bqnLAzTUvVkqPvhY4DV47X+Gl2c5Z8c3KNETnXp14GQt11LvxE8AwjzGxJ+rsikiOzg==",
       "dev": true
     },
     "chalk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "hasInstallScript": true,
       "devDependencies": {
+        "@double-great/stylelint-a11y": "^2.0.0",
         "autoprefixer": "10.4.7",
         "cssnano": "5.1.10",
         "postcss": "8.4.14",
@@ -57,6 +58,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@double-great/stylelint-a11y": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@double-great/stylelint-a11y/-/stylelint-a11y-2.0.0.tgz",
+      "integrity": "sha512-BZS+kPkS/Lhp/S8HyDIIix/LYFrS+aC8uj1EtIP4odnHayqZI5QCWBngS0rA2YbP3pG9ELKag0j5sBU3Qd9sMg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "stylelint": ">=13.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3725,6 +3738,13 @@
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
+    },
+    "@double-great/stylelint-a11y": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@double-great/stylelint-a11y/-/stylelint-a11y-2.0.0.tgz",
+      "integrity": "sha512-BZS+kPkS/Lhp/S8HyDIIix/LYFrS+aC8uj1EtIP4odnHayqZI5QCWBngS0rA2YbP3pG9ELKag0j5sBU3Qd9sMg==",
+      "dev": true,
+      "requires": {}
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "browser-update": "npx browserslist@latest --update-db"
   },
   "devDependencies": {
+    "@double-great/stylelint-a11y": "2.0.0",
     "autoprefixer": "10.4.7",
     "cssnano": "5.1.10",
     "postcss": "8.4.14",


### PR DESCRIPTION
- Adds the @double-great [fork of `stylelint-a11y`](https://github.com/double-great/stylelint-a11y) back to project
- Replaces rules that were removed in #319.
- Updates `caniuse-lite`