### PR TITLE
Update YouTube base links

### DIFF
--- a/app/Views/video.php
+++ b/app/Views/video.php
@@ -38,7 +38,7 @@ if ($build['video_type'] === 'youtube') {
           <iframe src="https://player.vimeo.com/video/<?= $build['video_id']; ?>?dnt=true&amp;portrait=0&amp;byline=0&amp;title=0&amp;autoplay=0&amp;color=ffffff" title="<?= $build['video_title']; ?> (embedded video)" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
         <?php endif; ?>
         <?php if ($build['video_type'] === 'youtube') :?>
-          <iframe src="https://www.youtube-nocookie.com/embed/<?= $build['video_id']; ?>?rel=0&amp;showinfo=0" title="<?= $build['video_title']; ?> (embedded video)" allowfullscreen></iframe>
+          <iframe src="https://www.youtube.com/embed/<?= $build['video_id']; ?>?rel=0&amp;showinfo=0" title="<?= $build['video_title']; ?> (embedded video)" allowfullscreen></iframe>
         <?php endif; ?>
       </div>
     </div>

--- a/app/Views/xml/rss.php
+++ b/app/Views/xml/rss.php
@@ -22,7 +22,7 @@ foreach ($build as $row) {
         echo '<p><iframe src="https://player.vimeo.com/video/' . $row->video_id . '?dnt=true&amp;portrait=0&amp;byline=0&amp;title=0&amp;autoplay=0&amp;color=ffffff" width="' . $row->video_width . '" height="' . $row->video_height . '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></p>';
     }
     if ($row->video_type === 'youtube') {
-        echo '<p><iframe width="' . $row->video_width . '" height="' . $row->video_height . '" src="https://www.youtube-nocookie.com/embed/' . $row->video_id . '?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe></p>';
+        echo '<p><iframe width="' . $row->video_width . '" height="' . $row->video_height . '" src="https://www.youtube.com/embed/' . $row->video_id . '?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe></p>';
     }
     echo ']]>';
     echo "</content:encoded>\n";

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -116,5 +116,5 @@ AddDefaultCharset utf-8
 </IfModule>
 
 # Set CSP Header
-Header set Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: https://www.youtube.com https://www.youtube-nocookie.com https://s.ytimg.com https://vimeo.com https://player.vimeo.com
+Header set Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: https://www.youtube.com https://youtube.com https://m.youtube.com https://s.ytimg.com https://vimeo.com https://player.vimeo.com
 


### PR DESCRIPTION
Remove the use of `https://www.youtube-nocookie.com` since it breaks more than it fixes. It sets cookies despite the name, too.