### PR TITLE
Address race condition

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -179,3 +179,10 @@ jobs:
           echo "$RELEASE_BODY" | gh release create ${{ steps.version.outputs.new_tag }} \
             --title "Release ${{ steps.version.outputs.new_tag }}" \
             --notes-file -
+            
+      - name: Trigger deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering deployment for release ${{ steps.version.outputs.new_tag }}"
+          gh workflow run deploy.yml -f tag=${{ steps.version.outputs.new_tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,12 @@ name: Deploy
 
 on:
   workflow_dispatch: # enable run button on github.com
-  push:
-    branches:
-      - "main"
+    inputs:
+      tag:
+        description: 'Tag to deploy (optional - uses latest if not specified)'
+        required: false
+        default: ''
+        type: string
 
 # prevent concurrency between different deploys
 concurrency: production_environment
@@ -60,32 +63,28 @@ jobs:
             ${{ runner.os }}-composer-
       - name: Composer install
         run: composer install
-      - name: Generate version tag
+      - name: Get version for Sentry
         id: version
         run: |
-          # Get the latest semantic version tag (v*.*.* format)
-          LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n1)
-
-          # If no semantic version tags exist, use v0.0.0
-          if [ -z "$LATEST_TAG" ]; then
-            LATEST_TAG="v0.0.0"
+          # Use provided tag or get the latest
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+            echo "Using provided tag: $TAG"
+          else
+            # Get the latest semantic version tag (v*.*.* format)
+            TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n1)
+            
+            # If no semantic version tags exist, use v0.0.0
+            if [ -z "$TAG" ]; then
+              TAG="v0.0.0"
+            fi
+            echo "Using latest tag: $TAG"
           fi
 
-          echo "Latest tag: $LATEST_TAG"
-
-          # Extract version numbers
-          VERSION=${LATEST_TAG#v}
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          MINOR=$(echo $VERSION | cut -d. -f2)
-          PATCH=$(echo $VERSION | cut -d. -f3)
-
-          # Increment patch version
-          PATCH=$((PATCH + 1))
-          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
-
-          echo "New tag: $NEW_TAG"
-          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
-          echo "new_version=${MAJOR}.${MINOR}.${PATCH}" >> $GITHUB_OUTPUT
+          # Extract version for Sentry release
+          VERSION=${TAG#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Deploy
         uses: deployphp/action@v1
         with:
@@ -93,44 +92,4 @@ jobs:
           dep: deploy stage=prod -vvv
         env:
           DOT_ENV: ${{ secrets.DOT_ENV }}
-          SENTRY_RELEASE: ${{ steps.version.outputs.new_version }}
-      - name: Extract PR information
-        id: pr_info
-        if: success()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Get the PR number from the latest commit message
-          PR_NUMBER=$(git log -1 --pretty=format:"%s" | grep -oE '#[0-9]+' | tr -d '#' | head -1)
-
-          if [ -n "$PR_NUMBER" ]; then
-            echo "Found PR #$PR_NUMBER"
-
-            # Get PR information using GitHub CLI
-            PR_DATA=$(gh pr view "$PR_NUMBER" --json title,body,author --jq '.')
-
-            PR_TITLE=$(echo "$PR_DATA" | jq -r '.title // "No title"')
-            PR_BODY=$(echo "$PR_DATA" | jq -r '.body // "No description"' | head -50) # Limit to first 50 lines
-            PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login // "Unknown"')
-
-            # Create the tag message
-            TAG_MESSAGE=$(printf "Release %s\n\nPR #%s: %s\nAuthor: @%s\n\n%s" \
-              "${{ steps.version.outputs.new_tag }}" \
-              "$PR_NUMBER" \
-              "$PR_TITLE" \
-              "$PR_AUTHOR" \
-              "$PR_BODY")
-
-            # Save to file to preserve formatting
-            echo "$TAG_MESSAGE" > .tag_message
-          else
-            echo "Release ${{ steps.version.outputs.new_tag }} - Direct commit to main" > .tag_message
-          fi
-      - name: Create and push tag
-        if: success()
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          git tag -a ${{ steps.version.outputs.new_tag }} -F .tag_message
-          git push origin ${{ steps.version.outputs.new_tag }}
-          rm -f .tag_message
+          SENTRY_RELEASE: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Description
  Fix race condition between auto-release and deploy workflows by establishing a sequential
  workflow execution order. The deploy workflow now triggers after the release is created,
  ensuring the correct version tag is available for Sentry tracking.

  ## Type of Change
  - [x] 🐛 Bug fix
  - [x] 🔧 Configuration change

  ## Testing
  - [ ] Local development environment
  - [ ] CI/CD passes

  ## PR Labels
  bug

  ## Additional Notes
  ### Changes made:
  1. Removed automatic deployment trigger on push to main from `deploy.yml`
  2. Added deployment trigger to `create-release.yml` that runs after tag creation
  3. Modified `deploy.yml` to accept an optional tag parameter for targeted deployments
  4. Updated version detection in `deploy.yml` to use the provided tag or fallback to latest

  ### Workflow sequence after merge:
  1. PR merge triggers `auto-release.yml`
  2. `auto-release.yml` analyzes PR and triggers `create-release.yml`
  3. `create-release.yml` creates version tag and GitHub release
  4. `create-release.yml` triggers `deploy.yml` with the new tag
  5. `deploy.yml` deploys with correct version for Sentry

  Manual deployments are still supported via workflow_dispatch.