### PR TITLE
Fix Sentry errors: Vimeo API handling and PHP 8.2/8.3 compatibility

### DIFF
--- a/app/Helpers/vimeo_helper.php
+++ b/app/Helpers/vimeo_helper.php
@@ -27,6 +27,11 @@ if (! function_exists('vimeo_get_feed')) {
             return $result;
         }
 
+        // Log error if we got a string response (likely an error message)
+        if (is_string($result)) {
+            log_message('error', 'Vimeo API returned error: ' . $result);
+        }
+
         return false;
     }
 }

--- a/app/Models/VimeoModels.php
+++ b/app/Models/VimeoModels.php
@@ -12,8 +12,8 @@ class VimeoModels extends Model
     /**
      * Search Vimeo feed for specific video.
      *
-     * @param object $feed
-     *                        Fetched YouTube feed.
+     * @param mixed  $feed
+     *                        Fetched Vimeo feed.
      * @param string $videoId
      *                        Video ID to look for.
      *
@@ -25,11 +25,20 @@ class VimeoModels extends Model
         $aggroModel = new AggroModels();
         helper('vimeo');
 
-        if ($feed === false) {
+        if ($feed === false || (! is_array($feed) && ! is_object($feed))) {
+            if ($feed !== false) {
+                log_message('error', 'VimeoModels::searchChannel received invalid feed data: ' . gettype($feed));
+            }
+
             return false;
         }
 
         foreach ($feed as $item) {
+            // Ensure item is an object before processing
+            if (! is_object($item) || ! isset($item->id)) {
+                continue;
+            }
+
             if ($videoId === $item->id && ! $aggroModel->checkVideo($item->id)) {
                 $video = vimeo_parse_meta($item);
                 $aggroModel->addVideo($video);
@@ -44,8 +53,8 @@ class VimeoModels extends Model
     /**
      * Parse Vimeo feed for videos.
      *
-     * @param object $feed
-     *                     Fetched YouTube feed.
+     * @param mixed $feed
+     *                    Fetched Vimeo feed.
      *
      * @return false|int
      *                   Number of videos added or false on error.
@@ -57,11 +66,22 @@ class VimeoModels extends Model
         helper('vimeo');
         $addCount = 0;
 
-        if ($feed === false) {
+        if ($feed === false || (! is_array($feed) && ! is_object($feed))) {
+            if ($feed !== false) {
+                log_message('error', 'VimeoModels::parseChannel received invalid feed data: ' . gettype($feed));
+            }
+
             return false;
         }
 
         foreach ($feed as $item) {
+            // Ensure item is an object before processing
+            if (! is_object($item) || ! isset($item->id)) {
+                log_message('warning', 'VimeoModels::parseChannel skipping invalid item');
+
+                continue;
+            }
+
             if (! $aggroModel->checkVideo($item->id)) {
                 $video = vimeo_parse_meta($item);
                 $aggroModel->addVideo($video);

--- a/app/Views/xml/feed.php
+++ b/app/Views/xml/feed.php
@@ -11,14 +11,14 @@ echo "<atom:link href=\"https://bmxfeed.com/feed\" rel=\"self\" type=\"applicati
 
 foreach ($build as $row) {
     echo "<item>\n";
-    echo '<title>' . stripslashes($row->site_name) . " on BMXfeed</title>\n";
+    echo '<title>' . stripslashes($row->site_name ?? '') . " on BMXfeed</title>\n";
     echo '<link>https://bmxfeed.com/sites/' . $row->site_slug . "</link>\n";
     echo '<description>';
-    echo '<![CDATA[<p>Updated <em>' . stripslashes($row->site_name) . '</em> on BMXfeed.';
+    echo '<![CDATA[<p>Updated <em>' . stripslashes($row->site_name ?? '') . '</em> on BMXfeed.';
     echo ' Check out <a href="https://bmxfeed.com/sites/' . $row->site_slug . '">https://bmxfeed.com/sites/' . $row->site_slug . '</a> for more info.</p>]]>';
     echo "</description>\n";
     echo '<guid isPermaLink="true">https://bmxfeed.com/sites/' . $row->site_slug . "</guid>\n";
-    echo '<pubDate>' . date('D, d M Y H:i:s O', strtotime($row->site_date_added)) . "</pubDate>\n";
+    echo '<pubDate>' . date('D, d M Y H:i:s O', strtotime($row->site_date_added ?? '')) . "</pubDate>\n";
     echo "</item>\n";
 }
 echo "</channel>\n";

--- a/app/Views/xml/rss.php
+++ b/app/Views/xml/rss.php
@@ -10,14 +10,14 @@ echo "<description>Recently spotted videos on bmxfeed.com</description>\n";
 
 foreach ($build as $row) {
     echo "<item>\n";
-    $row->video_title = str_replace(',', '', $row->video_title);
+    $row->video_title = str_replace(',', '', $row->video_title ?? '');
 
-    echo '<title>' . htmlspecialchars($row->video_title, ENT_XML1 | ENT_QUOTES, 'UTF-8') . "</title>\n";
+    echo '<title>' . htmlspecialchars($row->video_title ?? '', ENT_XML1 | ENT_QUOTES, 'UTF-8') . "</title>\n";
     echo '<link>https://bmxfeed.com/video/' . $row->video_id . "</link>\n";
-    echo '<description>Uploaded by ' . htmlspecialchars($row->video_source_username ?? '', ENT_QUOTES | ENT_IGNORE, 'UTF-8') . ' on ' . date('F j g:ia', strtotime($row->video_date_uploaded)) . ".</description>\n";
+    echo '<description>Uploaded by ' . htmlspecialchars($row->video_source_username ?? '', ENT_QUOTES | ENT_IGNORE, 'UTF-8') . ' on ' . date('F j g:ia', strtotime($row->video_date_uploaded ?? '')) . ".</description>\n";
     echo "<content:encoded>\n";
     echo '<![CDATA[';
-    echo '<p>Spotted <a href="https://bmxfeed.com/video/' . $row->video_id . '">' . htmlspecialchars($row->video_title, ENT_QUOTES, 'UTF-8') . '</a>. Uploaded by <a href="' . $row->video_source_url . '">' . htmlspecialchars($row->video_source_username ?? '', ENT_QUOTES | ENT_IGNORE, 'UTF-8') . '</a> on ' . date('F j g:ia', strtotime($row->video_date_uploaded)) . ".</p>\n";
+    echo '<p>Spotted <a href="https://bmxfeed.com/video/' . $row->video_id . '">' . htmlspecialchars($row->video_title ?? '', ENT_QUOTES, 'UTF-8') . '</a>. Uploaded by <a href="' . $row->video_source_url . '">' . htmlspecialchars($row->video_source_username ?? '', ENT_QUOTES | ENT_IGNORE, 'UTF-8') . '</a> on ' . date('F j g:ia', strtotime($row->video_date_uploaded ?? '')) . ".</p>\n";
     if ($row->video_type === 'vimeo') {
         echo '<p><iframe src="https://player.vimeo.com/video/' . $row->video_id . '?dnt=true&amp;portrait=0&amp;byline=0&amp;title=0&amp;autoplay=0&amp;color=ffffff" width="' . $row->video_width . '" height="' . $row->video_height . '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></p>';
     }
@@ -27,7 +27,7 @@ foreach ($build as $row) {
     echo ']]>';
     echo "</content:encoded>\n";
     echo '<guid isPermaLink="true">https://bmxfeed.com/video/' . $row->video_id . "</guid>\n";
-    echo '<pubDate>' . date('D, d M Y H:i:s O', strtotime($row->aggro_date_added)) . "</pubDate>\n";
+    echo '<pubDate>' . date('D, d M Y H:i:s O', strtotime($row->aggro_date_added ?? '')) . "</pubDate>\n";
     echo "</item>\n";
 }
 echo "</channel>\n";


### PR DESCRIPTION
## Description
This PR addresses two critical issues reported in Sentry:
1. TypeError when Vimeo API returns error messages during outages
2. PHP 8.2/8.3 deprecation warnings for passing null to non-nullable string parameters

## Type of Change
- [x] 🐛 Bug fix

## Testing
- [x] Local development environment
- [x] CI/CD passes

## Changes Made

### Vimeo API Error Handling
- Added type validation in `VimeoModels::parseChannel()` and `VimeoModels::searchChannel()` to handle non-object responses
- Added logging for string error responses in `vimeo_get_feed()`
- Prevents TypeError when Vimeo returns error messages like "We're having some problems receiving requests..."

### PHP 8.2/8.3 Compatibility
- Fixed null parameter issues in `app/Views/xml/rss.php` (5 occurrences)
- Fixed null parameter issues in `app/Views/xml/feed.php` (3 occurrences)
- Added null coalescing operators to functions: `strtotime()`, `htmlspecialchars()`, `stripslashes()`, `str_replace()`

## PR Labels
bug

## Additional Notes
- The trim() deprecation warning in Front.php was already fixed in a previous commit
- All code changes pass linting (phpcs, phpmd, phpstan)
- No breaking changes