### PR TITLE
Fix XML encoding issues in RSS feeds

### DIFF
--- a/app/Views/xml/feed.php
+++ b/app/Views/xml/feed.php
@@ -11,10 +11,12 @@ echo "<atom:link href=\"https://bmxfeed.com/feed\" rel=\"self\" type=\"applicati
 
 foreach ($build as $row) {
     echo "<item>\n";
-    echo '<title>' . stripslashes($row->site_name ?? '') . " on BMXfeed</title>\n";
+    // Remove control characters and properly encode for XML
+    $site_name = preg_replace('/[\x00-\x08\x0B-\x1F\x7F]/', ' ', $row->site_name ?? '');
+    echo '<title>' . htmlspecialchars($site_name, ENT_XML1 | ENT_QUOTES, 'UTF-8') . " on BMXfeed</title>\n";
     echo '<link>https://bmxfeed.com/sites/' . $row->site_slug . "</link>\n";
     echo '<description>';
-    echo '<![CDATA[<p>Updated <em>' . stripslashes($row->site_name ?? '') . '</em> on BMXfeed.';
+    echo '<![CDATA[<p>Updated <em>' . htmlspecialchars($site_name, ENT_QUOTES, 'UTF-8') . '</em> on BMXfeed.';
     echo ' Check out <a href="https://bmxfeed.com/sites/' . $row->site_slug . '">https://bmxfeed.com/sites/' . $row->site_slug . '</a> for more info.</p>]]>';
     echo "</description>\n";
     echo '<guid isPermaLink="true">https://bmxfeed.com/sites/' . $row->site_slug . "</guid>\n";

--- a/app/Views/xml/opml.php
+++ b/app/Views/xml/opml.php
@@ -10,7 +10,12 @@ echo "<body>\n";
 echo "<outline text=\"BMXfeed\">\n";
 
 foreach ($build as $row) {
-    echo '<outline title="' . htmlspecialchars($row->site_name ?? '') . '" text="' . htmlspecialchars($row->site_name ?? '') . '" type="rss" xmlUrl="' . htmlspecialchars($row->site_feed ?? '') . '" htmlUrl="' . htmlspecialchars($row->site_url ?? '') . "\" />\n";
+    // Remove control characters from all fields
+    $site_name = preg_replace('/[\x00-\x08\x0B-\x1F\x7F]/', ' ', $row->site_name ?? '');
+    $site_feed = preg_replace('/[\x00-\x08\x0B-\x1F\x7F]/', ' ', $row->site_feed ?? '');
+    $site_url  = preg_replace('/[\x00-\x08\x0B-\x1F\x7F]/', ' ', $row->site_url ?? '');
+
+    echo '<outline title="' . htmlspecialchars($site_name, ENT_XML1 | ENT_QUOTES, 'UTF-8') . '" text="' . htmlspecialchars($site_name, ENT_XML1 | ENT_QUOTES, 'UTF-8') . '" type="rss" xmlUrl="' . htmlspecialchars($site_feed, ENT_XML1 | ENT_QUOTES, 'UTF-8') . '" htmlUrl="' . htmlspecialchars($site_url, ENT_XML1 | ENT_QUOTES, 'UTF-8') . "\" />\n";
 }
 echo "</outline>\n";
 echo "</body>\n";

--- a/app/Views/xml/rss.php
+++ b/app/Views/xml/rss.php
@@ -11,6 +11,8 @@ echo "<description>Recently spotted videos on bmxfeed.com</description>\n";
 foreach ($build as $row) {
     echo "<item>\n";
     $row->video_title = str_replace(',', '', $row->video_title ?? '');
+    // Remove control characters (keeping tabs and newlines for now, removing other control chars)
+    $row->video_title = preg_replace('/[\x00-\x08\x0B-\x1F\x7F]/', ' ', $row->video_title);
 
     echo '<title>' . htmlspecialchars($row->video_title ?? '', ENT_XML1 | ENT_QUOTES, 'UTF-8') . "</title>\n";
     echo '<link>https://bmxfeed.com/video/' . $row->video_id . "</link>\n";

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,7 +24,6 @@ parameters:
         - '#Function helper not found.#'
         - '#Function esc not found.#'
         - '#Function log_message not found.#'
-        - '#Function quotes_to_entities not found.#'
         - '#Function clean_path not found.#'
         - '#Function lang not found.#'
         - '#Function config not found.#'

--- a/tests/unit/VimeoHelperTest.php
+++ b/tests/unit/VimeoHelperTest.php
@@ -203,10 +203,10 @@ final class VimeoHelperTest extends CIUnitTestCase
         $this->assertStringNotContainsString('&lt;', $result['video_title']);
         $this->assertStringNotContainsString('&gt;', $result['video_title']);
         $this->assertStringNotContainsString('&quot;', $result['video_source_username']);
-        
+
         // Verify raw values are preserved
-        $this->assertEquals('Video with "quotes" & <html>', $result['video_title']);
-        $this->assertEquals('User with "quotes"', $result['video_source_username']);
+        $this->assertSame('Video with "quotes" & <html>', $result['video_title']);
+        $this->assertSame('User with "quotes"', $result['video_source_username']);
     }
 
     public function testAllFunctionsExist(): void


### PR DESCRIPTION
## Description
Fixed XML parsing errors in RSS feeds caused by invalid control characters embedded in content. The RSS feed at `/rss` was throwing XML parsing errors due to control characters (specifically carriage returns) in video titles from the database.

## Type of Change
- [x] 🐛 Bug fix

## Testing
- [x] Local development environment
- [x] CI/CD passes

All tests pass with `fin composer test` and linting passes with `fin composer lint`.

## PR Labels
bug

## Additional Notes
This fix applies to all XML output endpoints:
- `/rss` - Video RSS feed
- `/feed` - Directory RSS feed  
- `/opml` - OPML feed

The solution filters out control characters (0x00-0x08, 0x0B-0x1F, 0x7F) that are invalid in XML and ensures proper XML entity encoding using `htmlspecialchars()` with the `ENT_XML1` flag.

Also cleaned up PHPStan configuration by removing an unused ignore pattern for `quotes_to_entities`.