### PR TITLE
Fix URL slug filtering to support YouTube IDs with leading hyphens

### DIFF
--- a/app/Services/ValidationService.php
+++ b/app/Services/ValidationService.php
@@ -9,14 +9,12 @@ class ValidationService
      */
     public function sanitizeSlug(string $slug): string
     {
-        // Remove any non-alphanumeric characters except hyphens
-        $slug = preg_replace('/[^a-zA-Z0-9\-]/', '', $slug);
+        // Remove any non-alphanumeric characters except hyphens and underscores
+        $slug = preg_replace('/[^a-zA-Z0-9\-_]/', '', $slug);
 
-        // Remove multiple consecutive hyphens
-        $slug = preg_replace('/-+/', '-', $slug);
-
-        // Trim hyphens from start and end
-        return trim($slug, '-');
+        // Remove multiple consecutive hyphens (but preserve single leading/trailing hyphens)
+        return preg_replace('/--+/', '-', $slug);
+        // Don't trim hyphens as they may be part of video IDs
     }
 
     /**

--- a/tests/unit/SecurityTest.php
+++ b/tests/unit/SecurityTest.php
@@ -95,7 +95,13 @@ final class SecurityTest extends DatabaseTestCase
         // Multiple hyphens should be reduced to single
         $this->assertSame('valid-slug', $this->validationService->sanitizeSlug('valid---slug'));
 
-        // Leading/trailing hyphens should be removed
-        $this->assertSame('valid', $this->validationService->sanitizeSlug('-valid-'));
+        // Leading/trailing hyphens should be preserved (for YouTube video IDs)
+        $this->assertSame('-valid-', $this->validationService->sanitizeSlug('-valid-'));
+
+        // Test YouTube video ID with leading hyphen
+        $this->assertSame('-Pp0Wg4gF54', $this->validationService->sanitizeSlug('-Pp0Wg4gF54'));
+
+        // Test underscore support
+        $this->assertSame('valid_slug', $this->validationService->sanitizeSlug('valid_slug'));
     }
 }


### PR DESCRIPTION
## Summary
- Fixed sanitizeSlug method that was breaking YouTube video URLs with leading hyphens
- Added support for underscores in slugs (valid in YouTube IDs)

## Problem
The `sanitizeSlug` method in `ValidationService.php` was trimming hyphens from the start and end of slugs. This caused YouTube video IDs that start with a hyphen (like `-Pp0Wg4gF54`) to be transformed incorrectly, resulting in 404 errors.

## Solution
- Modified `sanitizeSlug` to preserve leading/trailing hyphens
- Changed multiple hyphen reduction from `/-+/` to `/--+/` to only reduce 2+ consecutive hyphens
- Added support for underscores which are valid in YouTube video IDs
- Updated tests to reflect the new behavior

## Test plan
- [x] All existing tests pass (`fin composer test`)
- [x] Added specific test case for YouTube ID with leading hyphen
- [x] Added test for underscore support
- [x] Verified the example URL https://bmxfeed.com/video/-Pp0Wg4gF54 would now work correctly