### PR TITLE
Fix PHP version in cron configuration

### DIFF
--- a/.crontab
+++ b/.crontab
@@ -8,7 +8,7 @@ MAILTO=""
 
 ## aggro cron
 
-PHP_PATH='/usr/local/php82/bin/php'
+PHP_PATH='/usr/local/php84/bin/php'
 INDEX_PATH='/home/bmxfeed/aggro/current/public/index.php'
 
 ## aggro news


### PR DESCRIPTION
## Summary
- Updated cron configuration to use PHP 8.4 instead of PHP 8.2
- Ensures cron jobs run with the correct PHP version matching the application requirements

## Test plan
- [ ] Verify cron jobs execute successfully with PHP 8.4
- [ ] Monitor cron job logs for any errors after deployment
- [ ] Confirm scheduled tasks complete as expected