### PR TITLE
Verify deployment via SSH instead of HTTP

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -129,13 +129,15 @@ task('deploy:opcache_clear', static function () {
     $scriptPath = $releasePath . '/public/_opcache_clear_' . $token . '.php';
     $scriptUrl = $baseUrl . '/_opcache_clear_' . $token . '.php';
 
-    // Upload a one-shot opcache reset script
-    $scriptContent = '<?php if (function_exists("opcache_reset")) { opcache_reset(); echo "cleared"; } else { echo "no_opcache"; }';
+    // Upload a one-shot opcache and realpath cache reset script
+    $scriptContent = '<?php clearstatcache(true); if (function_exists("opcache_reset")) { opcache_reset(); echo "cleared"; } else { echo "no_opcache"; }';
     run("echo " . escapeshellarg($scriptContent) . " > " . escapeshellarg($scriptPath));
 
-    // Hit the script via HTTP
-    $result = runLocally("curl -s --max-time 10 '{$scriptUrl}'");
-    writeln("<info>opcache_reset result: {$result}</info>");
+    // Hit the script multiple times to reach different PHP-FPM workers
+    for ($i = 1; $i <= 3; $i++) {
+        $result = runLocally("curl -s --max-time 10 '{$scriptUrl}'");
+        writeln("<info>opcache_reset result ({$i}/3): {$result}</info>");
+    }
 
     // Remove the script
     run("rm -f " . escapeshellarg($scriptPath));
@@ -145,17 +147,29 @@ task('deploy:opcache_clear', static function () {
 task('deploy:verify', static function () {
     $baseUrl = get('base_url');
     $expectedRelease = get('release_name');
+    $maxAttempts = 3;
+    $retryDelaySecs = 5;
 
-    // Check /aggro/info
+    // Check /aggro/info with retries for cache propagation
     $infoUrl = $baseUrl . '/aggro/info';
     writeln("Verifying deployment at <info>{$infoUrl}</info>");
 
-    $infoStatus = runLocally("curl -s -o /tmp/deploy_verify.html -w '%{http_code}' '{$infoUrl}'");
-    $infoBody = runLocally('cat /tmp/deploy_verify.html');
+    $releaseMatched = false;
 
-    if ($infoStatus !== '200') {
-        warning("Info page returned HTTP {$infoStatus} (expected 200)");
-    } else {
+    for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+        if ($attempt > 1) {
+            writeln("<comment>Retry {$attempt}/{$maxAttempts} after {$retryDelaySecs}s (waiting for cache propagation)...</comment>");
+            runLocally("sleep {$retryDelaySecs}");
+        }
+
+        $infoStatus = runLocally("curl -s -o /tmp/deploy_verify.html -w '%{http_code}' '{$infoUrl}'");
+        $infoBody = runLocally('cat /tmp/deploy_verify.html');
+
+        if ($infoStatus !== '200') {
+            warning("Info page returned HTTP {$infoStatus} (expected 200)");
+            break;
+        }
+
         writeln('<info>Info page returned HTTP 200</info>');
 
         if (preg_match('/deploy:release=(\S+)/', $infoBody, $matches)) {
@@ -163,11 +177,16 @@ task('deploy:verify', static function () {
 
             if ($actualRelease === $expectedRelease) {
                 writeln("<info>Release number matches: {$actualRelease}</info>");
-            } else {
+                $releaseMatched = true;
+                break;
+            }
+
+            if ($attempt === $maxAttempts) {
                 warning("Release mismatch: expected {$expectedRelease}, got {$actualRelease}");
             }
         } else {
             warning('Could not find release marker in info page');
+            break;
         }
     }
 

--- a/deploy.php
+++ b/deploy.php
@@ -129,15 +129,13 @@ task('deploy:opcache_clear', static function () {
     $scriptPath = $releasePath . '/public/_opcache_clear_' . $token . '.php';
     $scriptUrl = $baseUrl . '/_opcache_clear_' . $token . '.php';
 
-    // Upload a one-shot opcache and realpath cache reset script
-    $scriptContent = '<?php clearstatcache(true); if (function_exists("opcache_reset")) { opcache_reset(); echo "cleared"; } else { echo "no_opcache"; }';
+    // Upload a one-shot opcache reset script
+    $scriptContent = '<?php if (function_exists("opcache_reset")) { opcache_reset(); echo "cleared"; } else { echo "no_opcache"; }';
     run("echo " . escapeshellarg($scriptContent) . " > " . escapeshellarg($scriptPath));
 
-    // Hit the script multiple times to reach different PHP-FPM workers
-    for ($i = 1; $i <= 3; $i++) {
-        $result = runLocally("curl -s --max-time 10 '{$scriptUrl}'");
-        writeln("<info>opcache_reset result ({$i}/3): {$result}</info>");
-    }
+    // Hit the script via HTTP
+    $result = runLocally("curl -s --max-time 10 '{$scriptUrl}'");
+    writeln("<info>opcache_reset result: {$result}</info>");
 
     // Remove the script
     run("rm -f " . escapeshellarg($scriptPath));
@@ -146,51 +144,29 @@ task('deploy:opcache_clear', static function () {
 // Verify deployment by checking the live site.
 task('deploy:verify', static function () {
     $baseUrl = get('base_url');
+    $deployPath = get('deploy_path');
     $expectedRelease = get('release_name');
-    $maxAttempts = 3;
-    $retryDelaySecs = 5;
 
-    // Check /aggro/info with retries for cache propagation
-    $infoUrl = $baseUrl . '/aggro/info';
-    writeln("Verifying deployment at <info>{$infoUrl}</info>");
+    // Verify release via SSH (filesystem is authoritative, not subject to PHP-FPM caching)
+    $currentTarget = run("readlink {$deployPath}/current");
+    $actualRelease = basename($currentTarget);
+    writeln("Symlink target: <info>{$currentTarget}</info>");
 
-    $releaseMatched = false;
-
-    for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
-        if ($attempt > 1) {
-            writeln("<comment>Retry {$attempt}/{$maxAttempts} after {$retryDelaySecs}s (waiting for cache propagation)...</comment>");
-            runLocally("sleep {$retryDelaySecs}");
-        }
-
-        $infoStatus = runLocally("curl -s -o /tmp/deploy_verify.html -w '%{http_code}' '{$infoUrl}'");
-        $infoBody = runLocally('cat /tmp/deploy_verify.html');
-
-        if ($infoStatus !== '200') {
-            warning("Info page returned HTTP {$infoStatus} (expected 200)");
-            break;
-        }
-
-        writeln('<info>Info page returned HTTP 200</info>');
-
-        if (preg_match('/deploy:release=(\S+)/', $infoBody, $matches)) {
-            $actualRelease = $matches[1];
-
-            if ($actualRelease === $expectedRelease) {
-                writeln("<info>Release number matches: {$actualRelease}</info>");
-                $releaseMatched = true;
-                break;
-            }
-
-            if ($attempt === $maxAttempts) {
-                warning("Release mismatch: expected {$expectedRelease}, got {$actualRelease}");
-            }
-        } else {
-            warning('Could not find release marker in info page');
-            break;
-        }
+    if ($actualRelease === $expectedRelease) {
+        writeln("<info>Release number matches: {$actualRelease}</info>");
+    } else {
+        warning("Release mismatch: expected {$expectedRelease}, got {$actualRelease}");
     }
 
-    // Check homepage
+    // Verify .env has the correct DEPLOY_RELEASE
+    $envRelease = run("grep -oP \"DEPLOY_RELEASE='\\K[^']+\" {$deployPath}/current/.env || echo 'not found'");
+    if ($envRelease === $expectedRelease) {
+        writeln("<info>.env DEPLOY_RELEASE matches: {$envRelease}</info>");
+    } else {
+        warning(".env DEPLOY_RELEASE mismatch: expected {$expectedRelease}, got {$envRelease}");
+    }
+
+    // HTTP smoke test (just check that the site responds)
     $homeStatus = runLocally("curl -s -o /dev/null -w '%{http_code}' '{$baseUrl}/'");
 
     if ($homeStatus !== '200') {
@@ -198,8 +174,6 @@ task('deploy:verify', static function () {
     } else {
         writeln('<info>Homepage returned HTTP 200</info>');
     }
-
-    runLocally('rm -f /tmp/deploy_verify.html');
 });
 
 desc('Deploy the application');


### PR DESCRIPTION
## Summary

- Verify release number by reading the `current` symlink target via SSH (filesystem truth)
- Verify `.env` `DEPLOY_RELEASE` value directly via SSH
- Revert opcache clear to single request (multi-hit from #779 didn't help)
- Keep HTTP as a smoke test only (homepage returns 200)

## Context

Follow-up to #779. The HTTP-based release verification is unreliable on DreamHost shared hosting because PHP-FPM workers cache symlink paths in their **realpath cache**. After `deploy:symlink` swaps the `current` symlink, HTTP requests continue serving from the old release directory until the cache expires (~120s). Retries don't help because all FPM workers have the same stale cache.

SSH commands read the filesystem directly and are not subject to PHP-FPM caching, making them the reliable way to verify the deploy actually landed.

## Test plan

- [ ] Deploy and confirm symlink target matches expected release
- [ ] Confirm `.env` `DEPLOY_RELEASE` matches expected release
- [ ] Confirm homepage HTTP 200 check still runs
- [ ] No more false "Release mismatch" warnings