### PR TITLE
Update composer, reduce cyclomatic complexity

### DIFF
--- a/app/Controllers/Aggro.php
+++ b/app/Controllers/Aggro.php
@@ -263,27 +263,13 @@ class Aggro extends BaseController
         }
 
         if ($videoID === null) {
-            $data['stale'] = $aggroModel->getChannels('30', 'vimeo', '5');
+            $stale = $aggroModel->getChannels('30', 'vimeo', '5');
 
-            if ($data['stale'] === false || empty($data['stale'])) {
+            if ($stale === false || empty($stale)) {
                 return false;
             }
 
-            foreach ($data['stale'] as $channel) {
-                $data['feed'] = vimeo_get_feed($channel->source_channel_id);
-
-                if ($data['feed'] === false) {
-                    $aggroModel->incrementChannelFailCount($channel->source_slug);
-                    $aggroModel->updateChannel($channel->source_slug);
-
-                    continue;
-                }
-
-                $aggroModel->resetChannelFailCount($channel->source_slug);
-                $data['number_added'] = $vimeoModel->parseChannel($data['feed']);
-                echo "\nAdded " . $data['number_added'] . ' videos from ' . $channel->source_name . ".\n";
-                $aggroModel->updateChannel($channel->source_slug);
-            }
+            $this->processStaleVimeoChannels($stale, $aggroModel, $vimeoModel);
 
             return true;
         }
@@ -327,27 +313,13 @@ class Aggro extends BaseController
         }
 
         if ($videoID === null) {
-            $data['stale'] = $aggroModel->getChannels('30', 'youtube', '5');
+            $stale = $aggroModel->getChannels('30', 'youtube', '5');
 
-            if ($data['stale'] === false || empty($data['stale'])) {
+            if ($stale === false || empty($stale)) {
                 return false;
             }
 
-            foreach ($data['stale'] as $channel) {
-                $data['feed'] = youtube_get_feed($channel->source_channel_id);
-
-                if ($data['feed'] === false || $data['feed']->error()) {
-                    $aggroModel->incrementChannelFailCount($channel->source_slug);
-                    $aggroModel->updateChannel($channel->source_slug);
-
-                    continue;
-                }
-
-                $aggroModel->resetChannelFailCount($channel->source_slug);
-                $data['number_added'] = $youtubeModel->parseChannel($data['feed']);
-                echo "\nAdded " . $data['number_added'] . ' videos from ' . $channel->source_name . ".\n";
-                $aggroModel->updateChannel($channel->source_slug);
-            }
+            $this->processStaleYoutubeChannels($stale, $aggroModel, $youtubeModel);
 
             return true;
         }
@@ -372,5 +344,49 @@ class Aggro extends BaseController
         echo "\nAdded https://www.youtube.com/watch?v=" . $videoID . ' from ' . $sourceID . ".\n";
 
         return true;
+    }
+
+    /**
+     * Process stale Vimeo channels.
+     */
+    private function processStaleVimeoChannels(array $stale, AggroModels $aggroModel, VimeoModels $vimeoModel): void
+    {
+        foreach ($stale as $channel) {
+            $feed = vimeo_get_feed($channel->source_channel_id);
+
+            if ($feed === false) {
+                $aggroModel->incrementChannelFailCount($channel->source_slug);
+                $aggroModel->updateChannel($channel->source_slug);
+
+                continue;
+            }
+
+            $aggroModel->resetChannelFailCount($channel->source_slug);
+            $numberAdded = $vimeoModel->parseChannel($feed);
+            echo "\nAdded " . $numberAdded . ' videos from ' . $channel->source_name . ".\n";
+            $aggroModel->updateChannel($channel->source_slug);
+        }
+    }
+
+    /**
+     * Process stale YouTube channels.
+     */
+    private function processStaleYoutubeChannels(array $stale, AggroModels $aggroModel, YoutubeModels $youtubeModel): void
+    {
+        foreach ($stale as $channel) {
+            $feed = youtube_get_feed($channel->source_channel_id);
+
+            if ($feed === false || $feed->error()) {
+                $aggroModel->incrementChannelFailCount($channel->source_slug);
+                $aggroModel->updateChannel($channel->source_slug);
+
+                continue;
+            }
+
+            $aggroModel->resetChannelFailCount($channel->source_slug);
+            $numberAdded = $youtubeModel->parseChannel($feed);
+            echo "\nAdded " . $numberAdded . ' videos from ' . $channel->source_name . ".\n";
+            $aggroModel->updateChannel($channel->source_slug);
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -891,16 +891,16 @@
         },
         {
             "name": "nexusphp/cs-config",
-            "version": "v3.28.2",
+            "version": "v3.28.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/NexusPHP/cs-config.git",
-                "reference": "764a5550ffafd8d517c7f7afe6ba767cd051d6d4"
+                "reference": "fb6bd0d2e1a51bd2908b1a1032f0049a6465df2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/NexusPHP/cs-config/zipball/764a5550ffafd8d517c7f7afe6ba767cd051d6d4",
-                "reference": "764a5550ffafd8d517c7f7afe6ba767cd051d6d4",
+                "url": "https://api.github.com/repos/NexusPHP/cs-config/zipball/fb6bd0d2e1a51bd2908b1a1032f0049a6465df2e",
+                "reference": "fb6bd0d2e1a51bd2908b1a1032f0049a6465df2e",
                 "shasum": ""
             },
             "require": {
@@ -938,7 +938,7 @@
                 "slack": "https://nexusphp.slack.com",
                 "source": "https://github.com/NexusPHP/cs-config.git"
             },
-            "time": "2026-04-11T19:32:22+00:00"
+            "time": "2026-04-17T10:46:08+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -4290,11 +4290,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.46",
+            "version": "2.1.51",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
-                "reference": "a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc3b523c45e714c70de2ac5113b958223b55dc59",
+                "reference": "dc3b523c45e714c70de2ac5113b958223b55dc59",
                 "shasum": ""
             },
             "require": {
@@ -4339,7 +4339,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-01T09:25:14+00:00"
+            "time": "2026-04-21T18:22:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
## Summary
- Update composer dependencies
- Extract stale channel processing loops from `getVimeo` and `getYoutube` into private methods to reduce cyclomatic complexity below the phpcs threshold of 7

## Test plan
- [x] All existing tests pass (`phpunit`: 547 tests, 0 failures)
- [x] phpcs reports 0 errors and 0 warnings on `Aggro.php`