### PR TITLE
Reduce Sentry noise from feed fetch errors (AGGRO-N)

### DIFF
--- a/app/Helpers/aggro_helper.php
+++ b/app/Helpers/aggro_helper.php
@@ -188,7 +188,7 @@ if (! function_exists('fetch_feed')) {
 
         if ($rss->error()) {
             $errormsg = $feed . ' - ' . $rss->error();
-            log_message('error', $errormsg);
+            log_message('warning', $errormsg);
         }
 
         return $rss;

--- a/app/Repositories/ChannelRepository.php
+++ b/app/Repositories/ChannelRepository.php
@@ -56,7 +56,7 @@ class ChannelRepository
         $query = $this->db->table('aggro_sources')
             ->where('source_type', $type)
             ->where('source_date_updated <=', $staleDateTime)
-            ->where('source_fail_count <', 20)
+            ->where('source_fail_count <', 5)
             ->orderBy('source_date_updated', 'ASC')
             ->limit((int) $limit)
             ->get();

--- a/tests/unit/ChannelRepositoryTest.php
+++ b/tests/unit/ChannelRepositoryTest.php
@@ -151,7 +151,7 @@ final class ChannelRepositoryTest extends RepositoryTestCase
             'source_slug'         => 'failing_channel',
             'source_type'         => 'youtube',
             'source_date_updated' => date('Y-m-d H:i:s', strtotime('-2 hours')),
-            'source_fail_count'   => 20,
+            'source_fail_count'   => 5,
         ]);
 
         $this->db->table('aggro_sources')->insertBatch([$healthyChannel, $failingChannel]);
@@ -172,7 +172,7 @@ final class ChannelRepositoryTest extends RepositoryTestCase
             'source_slug'         => 'recovering_channel',
             'source_type'         => 'youtube',
             'source_date_updated' => date('Y-m-d H:i:s', strtotime('-2 hours')),
-            'source_fail_count'   => 19,
+            'source_fail_count'   => 4,
         ]);
 
         $this->db->table('aggro_sources')->insert($channel);


### PR DESCRIPTION
## Summary

- Downgrade `fetch_feed()` log level from `error` to `warning` so feed fetch failures (404/500) are no longer forwarded to Sentry via `SentryLogHandler`
- Lower dead channel fail threshold from 20 to 5 consecutive failures to reduce wasted HTTP requests
- Update tests to match new threshold

## Context

Sentry issue AGGRO-N accumulated 15,405 events. Commit 30fa242 added fail count tracking to stop polling dead channels after 20 failures, but errors continued to mount because `fetch_feed()` logs at `error` level — which `SentryLogHandler` captures — before the controller gets a chance to handle the failure gracefully. Intermittent 500s also reset the counter, so flaky channels never reached the threshold.

Feed failures are expected operational conditions, not bugs. The warning-level log is still written to CI4 log files for debugging.

## Test plan

- [x] All 547 tests pass
- [x] Linting clean (pre-existing PHPMD complexity warning unchanged)
- [ ] Post-deploy: monitor Sentry issue AGGRO-N for drop in event volume