### PR TITLE
Add exponential backoff for failing channel fetches (AGGRO-N)

### DIFF
--- a/app/Repositories/ChannelRepository.php
+++ b/app/Repositories/ChannelRepository.php
@@ -10,6 +10,21 @@ use Config\Database;
  */
 class ChannelRepository
 {
+    /**
+     * Multiplier applied to the stale window per consecutive failure count.
+     * Index = source_fail_count, value = multiplier on $stale minutes.
+     * The final entry applies to all fail counts at or above its index.
+     * Example with $stale = 30: 0 fails -> 30min, 1 -> 1h, 2 -> 2h, 3 -> 4h,
+     * 4 -> 8h, 5+ -> 24h.
+     */
+    private const FAIL_BACKOFF_MULTIPLIERS = [1, 2, 4, 8, 16, 48];
+
+    /**
+     * Channels with at least this many consecutive failures are skipped
+     * entirely until source_fail_count is reset by a successful fetch.
+     */
+    private const FAIL_COUNT_HARD_CAP = 20;
+
     protected $db;
     protected $utilityModel;
 
@@ -51,12 +66,32 @@ class ChannelRepository
      */
     private function fetchStaleChannels($stale, $type, $limit)
     {
-        $staleDateTime = date('Y-m-d H:i:s', strtotime("-{$stale} minutes"));
+        $now     = time();
+        $cutoffs = [];
 
-        $query = $this->db->table('aggro_sources')
+        foreach (self::FAIL_BACKOFF_MULTIPLIERS as $bucket => $multiplier) {
+            $cutoffs[$bucket] = date('Y-m-d H:i:s', $now - ((int) $stale * 60 * $multiplier));
+        }
+        $lastBucket = array_key_last(self::FAIL_BACKOFF_MULTIPLIERS);
+
+        $builder = $this->db->table('aggro_sources')
             ->where('source_type', $type)
-            ->where('source_date_updated <=', $staleDateTime)
-            ->where('source_fail_count <', 20)
+            ->where('source_fail_count <', self::FAIL_COUNT_HARD_CAP)
+            ->groupStart();
+
+        foreach (array_keys(self::FAIL_BACKOFF_MULTIPLIERS) as $bucket) {
+            $bucket === 0 ? $builder->groupStart() : $builder->orGroupStart();
+
+            if ($bucket === $lastBucket) {
+                $builder->where('source_fail_count >=', $bucket);
+            } else {
+                $builder->where('source_fail_count', $bucket);
+            }
+
+            $builder->where('source_date_updated <=', $cutoffs[$bucket])->groupEnd();
+        }
+
+        $query = $builder->groupEnd()
             ->orderBy('source_date_updated', 'ASC')
             ->limit((int) $limit)
             ->get();

--- a/tests/unit/ChannelRepositoryTest.php
+++ b/tests/unit/ChannelRepositoryTest.php
@@ -167,11 +167,12 @@ final class ChannelRepositoryTest extends RepositoryTestCase
 
     public function testGetChannelsIncludesChannelsBelowFailureThreshold()
     {
-        // Arrange
+        // A channel one fail short of the hard cap is still eligible once its
+        // backoff window has elapsed (24 hours for fail_count >= 5).
         $channel = $this->createTestChannel([
             'source_slug'         => 'recovering_channel',
             'source_type'         => 'youtube',
-            'source_date_updated' => date('Y-m-d H:i:s', strtotime('-2 hours')),
+            'source_date_updated' => date('Y-m-d H:i:s', strtotime('-25 hours')),
             'source_fail_count'   => 19,
         ]);
 
@@ -184,6 +185,86 @@ final class ChannelRepositoryTest extends RepositoryTestCase
         $this->assertIsArray($results);
         $this->assertCount(1, $results);
         $this->assertSame('recovering_channel', $results[0]->source_slug);
+    }
+
+    public function testFailingChannelIsNotStaleWithinBackoffWindow()
+    {
+        // fail_count=2 -> 2-hour backoff window; -1 hour should be excluded.
+        $channel = $this->createTestChannel([
+            'source_slug'         => 'backoff_pending',
+            'source_type'         => 'youtube',
+            'source_date_updated' => date('Y-m-d H:i:s', strtotime('-1 hour')),
+            'source_fail_count'   => 2,
+        ]);
+
+        $this->db->table('aggro_sources')->insert($channel);
+
+        $results = $this->repository->getChannels('30', 'youtube', '10');
+
+        $this->assertFalse($results);
+    }
+
+    public function testFailingChannelBecomesStaleAfterBackoffWindow()
+    {
+        // fail_count=2 -> 2-hour backoff window; -3 hours should be eligible.
+        $channel = $this->createTestChannel([
+            'source_slug'         => 'backoff_elapsed',
+            'source_type'         => 'youtube',
+            'source_date_updated' => date('Y-m-d H:i:s', strtotime('-3 hours')),
+            'source_fail_count'   => 2,
+        ]);
+
+        $this->db->table('aggro_sources')->insert($channel);
+
+        $results = $this->repository->getChannels('30', 'youtube', '10');
+
+        $this->assertIsArray($results);
+        $this->assertCount(1, $results);
+        $this->assertSame('backoff_elapsed', $results[0]->source_slug);
+    }
+
+    public function testBackoffCapsAt24Hours()
+    {
+        // fail_count=10 falls into the 5+ bucket (24-hour cap).
+        $withinCap = $this->createTestChannel([
+            'source_slug'         => 'still_in_cooldown',
+            'source_type'         => 'youtube',
+            'source_date_updated' => date('Y-m-d H:i:s', strtotime('-23 hours')),
+            'source_fail_count'   => 10,
+        ]);
+        $pastCap = $this->createTestChannel([
+            'source_slug'         => 'cap_elapsed',
+            'source_type'         => 'youtube',
+            'source_date_updated' => date('Y-m-d H:i:s', strtotime('-25 hours')),
+            'source_fail_count'   => 10,
+        ]);
+
+        $this->db->table('aggro_sources')->insertBatch([$withinCap, $pastCap]);
+
+        $results = $this->repository->getChannels('30', 'youtube', '10');
+
+        $this->assertIsArray($results);
+        $this->assertCount(1, $results);
+        $this->assertSame('cap_elapsed', $results[0]->source_slug);
+    }
+
+    public function testHealthyChannelStaleWindowUnchanged()
+    {
+        // fail_count=0 keeps the original 30-minute stale window.
+        $channel = $this->createTestChannel([
+            'source_slug'         => 'healthy_stale',
+            'source_type'         => 'youtube',
+            'source_date_updated' => date('Y-m-d H:i:s', strtotime('-31 minutes')),
+            'source_fail_count'   => 0,
+        ]);
+
+        $this->db->table('aggro_sources')->insert($channel);
+
+        $results = $this->repository->getChannels('30', 'youtube', '10');
+
+        $this->assertIsArray($results);
+        $this->assertCount(1, $results);
+        $this->assertSame('healthy_stale', $results[0]->source_slug);
     }
 
     public function testIncrementChannelFailCount()


### PR DESCRIPTION
## Summary

- Bucket the stale-window check in `ChannelRepository::fetchStaleChannels()` on `source_fail_count` so each consecutive failure doubles the wait before the next retry: 0 → 30 min, 1 → 1 h, 2 → 2 h, 3 → 4 h, 4 → 8 h, 5+ → 24 h (cap).
- Hard cap of 20 consecutive failures unchanged.
- No schema migration required — reuses the existing `source_fail_count` and `source_date_updated` columns.

## Context

After PR #786 lowered the dead-channel skip threshold from 20 → 5, every YouTube channel hit `source_fail_count = 5` within a day and was being skipped entirely. PR #790 reverted the limit to 20 and counters were reset in production, restoring fetches.

The underlying issue is that the fetcher retried every channel every 30 minutes regardless of recent failures. A channel returning intermittent 4xx/5xx errors burned a fetch slot every cycle and raced toward the cap. With this change, a permanently broken channel reaches `source_fail_count = 20` only after ~17 days of continuous failure rather than ~10 hours, while intermittent blips have time to recover (the counter resets on the first successful fetch).

The existing controller flow already increments `source_fail_count` and updates `source_date_updated` on failure, so no controller changes are needed — the new bucketed query gives the backoff for free.

## Test plan

- [x] All 551 tests pass (`ddev exec composer test`)
- [x] 4 new tests in `ChannelRepositoryTest` cover within-window exclusion, after-window inclusion, 24-hour cap, and healthy-channel regression
- [x] Existing `testGetChannelsIncludesChannelsBelowFailureThreshold` updated to use `-25 hours` so it still asserts inclusion under the new 24-hour bucket for `fail_count = 19`
- [x] phpfix / phpcs / phpstan clean (pre-existing PHPMD complexity warning on `Aggro.php` unchanged)
- [ ] Post-deploy: monitor `aggro_sources` — average `source_fail_count` should trend down for intermittently failing channels, and Sentry AGGRO-N volume should stay low