### PR TITLE
Retry per-feed transaction on MySQL deadlock (AGGRO-1S)

### DIFF
--- a/app/Models/NewsModels.php
+++ b/app/Models/NewsModels.php
@@ -136,20 +136,60 @@ class NewsModels extends Model
      */
     private function saveFeedItems($row, $fetch)
     {
-        $this->db->transStart();
+        $maxAttempts = 3;
+        $delaysMs    = [50, 150, 400];
 
-        $this->updateLastFetchTime($row->site_id);
-        $this->processFeedItems($row, $fetch);
+        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+            $this->db->transStart();
 
-        $this->db->transComplete();
+            $this->updateLastFetchTime($row->site_id);
+            $this->processFeedItems($row, $fetch);
 
-        if ($this->db->transStatus() === false) {
-            log_message('error', 'Transaction failed for site_id ' . $row->site_id);
+            $this->db->transComplete();
+
+            if ($this->db->transStatus() !== false) {
+                return true;
+            }
+
+            if ($this->isDeadlockError() && $attempt < $maxAttempts) {
+                $base   = $delaysMs[$attempt - 1];
+                $jitter = random_int(0, $base);
+                $this->sleepBetweenAttempts($base + $jitter);
+
+                continue;
+            }
+
+            log_message(
+                'error',
+                'Transaction failed for site_id ' . $row->site_id
+                . ' (attempt ' . $attempt . '/' . $maxAttempts . ')',
+            );
 
             return false;
         }
 
-        return true;
+        return false;
+    }
+
+    /**
+     * Detect a transient MySQL deadlock or lock-wait timeout from the last query.
+     */
+    private function isDeadlockError(): bool
+    {
+        $error = $this->db->error();
+        $code  = (int) ($error['code'] ?? 0);
+
+        return $code === 1213
+            || $code === 1205
+            || ($error['sqlstate'] ?? '') === '40001';
+    }
+
+    /**
+     * Sleep between retry attempts. Extracted so tests can override it.
+     */
+    protected function sleepBetweenAttempts(int $ms): void
+    {
+        usleep($ms * 1000);
     }
 
     /**

--- a/tests/unit/NewsModelsTest.php
+++ b/tests/unit/NewsModelsTest.php
@@ -572,4 +572,154 @@ final class NewsModelsTest extends ServiceTestCase
         $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
+
+    public function testSaveFeedItemsRetriesOnDeadlockAndSucceeds()
+    {
+        $stubDb = $this->makeTransactionStub(
+            [false, true],
+            [['code' => 1213, 'message' => 'Deadlock found', 'sqlstate' => '40001']],
+        );
+        $model = $this->makeModelWithStubbedDb($stubDb);
+
+        $result = $this->invokeSaveFeedItems($model, $stubDb);
+
+        $this->assertTrue($result);
+        $this->assertSame(2, $stubDb->countCalls('transStart'));
+        $this->assertSame(1, $model->sleepCallCount);
+    }
+
+    public function testSaveFeedItemsGivesUpAfterMaxDeadlockRetries()
+    {
+        $stubDb = $this->makeTransactionStub(
+            [false, false, false],
+            [
+                ['code' => 1213, 'message' => 'Deadlock found', 'sqlstate' => '40001'],
+                ['code' => 1213, 'message' => 'Deadlock found', 'sqlstate' => '40001'],
+                ['code' => 1213, 'message' => 'Deadlock found', 'sqlstate' => '40001'],
+            ],
+        );
+        $model = $this->makeModelWithStubbedDb($stubDb);
+
+        $result = $this->invokeSaveFeedItems($model, $stubDb);
+
+        $this->assertFalse($result);
+        $this->assertSame(3, $stubDb->countCalls('transStart'));
+        $this->assertSame(2, $model->sleepCallCount);
+    }
+
+    public function testSaveFeedItemsDoesNotRetryOnNonDeadlockFailure()
+    {
+        $stubDb = $this->makeTransactionStub(
+            [false],
+            [['code' => 1062, 'message' => 'Duplicate entry', 'sqlstate' => '23000']],
+        );
+        $model = $this->makeModelWithStubbedDb($stubDb);
+
+        $result = $this->invokeSaveFeedItems($model, $stubDb);
+
+        $this->assertFalse($result);
+        $this->assertSame(1, $stubDb->countCalls('transStart'));
+        $this->assertSame(0, $model->sleepCallCount);
+    }
+
+    public function testSaveFeedItemsSucceedsFirstTryWithoutRetryOverhead()
+    {
+        $stubDb = $this->makeTransactionStub([true], []);
+        $model  = $this->makeModelWithStubbedDb($stubDb);
+
+        $result = $this->invokeSaveFeedItems($model, $stubDb);
+
+        $this->assertTrue($result);
+        $this->assertSame(1, $stubDb->countCalls('transStart'));
+        $this->assertSame(0, $model->sleepCallCount);
+    }
+
+    private function makeTransactionStub(array $transStatusReturns, array $errorReturns): object
+    {
+        return new class ($transStatusReturns, $errorReturns) {
+            public array $calls = [];
+            private array $transStatusReturns;
+            private array $errorReturns;
+
+            public function __construct(array $transStatusReturns, array $errorReturns)
+            {
+                $this->transStatusReturns = $transStatusReturns;
+                $this->errorReturns       = $errorReturns;
+            }
+
+            public function transStart(): void
+            {
+                $this->calls[] = 'transStart';
+            }
+
+            public function transComplete(): void
+            {
+                $this->calls[] = 'transComplete';
+            }
+
+            public function transStatus(): bool
+            {
+                return array_shift($this->transStatusReturns) ?? true;
+            }
+
+            public function error(): array
+            {
+                return array_shift($this->errorReturns) ?? ['code' => 0, 'message' => '', 'sqlstate' => ''];
+            }
+
+            public function table(string $name): object
+            {
+                return new class () {
+                    public function where($key, $value = null): self
+                    {
+                        return $this;
+                    }
+
+                    public function update($data): bool
+                    {
+                        return true;
+                    }
+                };
+            }
+
+            public function countCalls(string $method): int
+            {
+                return count(array_filter($this->calls, static fn ($c) => $c === $method));
+            }
+        };
+    }
+
+    private function makeModelWithStubbedDb(object $stubDb): NewsModels
+    {
+        $model = new class () extends NewsModels {
+            public int $sleepCallCount = 0;
+
+            protected function sleepBetweenAttempts(int $ms): void
+            {
+                $this->sleepCallCount++;
+            }
+        };
+
+        $reflection = new ReflectionClass(NewsModels::class);
+        $dbProp     = $reflection->getProperty('db');
+        $dbProp->setValue($model, $stubDb);
+
+        return $model;
+    }
+
+    private function invokeSaveFeedItems(NewsModels $model, object $stubDb): bool
+    {
+        $row        = (object) ['site_id' => 1];
+        $emptyFetch = new class () {
+            public function get_items(int $start = 0, int $end = 0): array
+            {
+                return [];
+            }
+        };
+
+        $reflection = new ReflectionClass(NewsModels::class);
+        $method     = $reflection->getMethod('saveFeedItems');
+
+        return $method->invoke($model, $row, $emptyFetch);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a bounded retry loop (3 attempts, jittered 50/150/400 ms backoff) around the per-feed transaction in `NewsModels::saveFeedItems()`.
- Detects MySQL deadlock (errno 1213), lock-wait timeout (1205), and SQLSTATE 40001 via `$this->db->error()` after a failed `transComplete()`.
- Includes the attempt count in the failure log line for observability.

## Why

Sentry [AGGRO-1S](https://bmxfeed.sentry.io/issues/AGGRO-1S) surfaced one production deadlock on `REPLACE INTO news_featured`. The every-6-minute `aggro news` cron can overlap itself, and the per-feed transaction holds locks on both `news_feeds` and the `story_permalink` unique index — enough surface to deadlock under concurrency. MySQL's guidance is for the application to retry.

No schema, cron, or controller changes. Retry boundary is the existing transaction; the in-memory `$fetch` is reused so retries are cheap.

## Test plan

- [x] `ddev exec composer test:unit` — 537 tests pass (32 skipped for external services as before).
- [x] 4 new tests in `NewsModelsTest.php` cover: retry-then-succeed, exhausted retries, no-retry on non-deadlock failures, no-overhead happy path.
- [x] `ddev exec vendor/bin/php-cs-fixer fix`, PHPCS, PHPStan all clean. PHPMD reports a pre-existing class-complexity warning on `Aggro.php` that exists on `main` and is unrelated to this change.
- [ ] Post-merge: monitor Sentry AGGRO-1S for resolution or for `attempt 3/3` log entries that would justify a follow-up (e.g., cron-level flock).