### PR TITLE
Analyse app/Helpers with phpstan and resolve findings

### DIFF
--- a/app/Controllers/Aggro.php
+++ b/app/Controllers/Aggro.php
@@ -289,7 +289,7 @@ class Aggro extends BaseController
 
         if (! $aggroModel->checkVideo($videoID)) {
             $request              = 'https://vimeo.com/api/v2/video/' . $videoID . '.json';
-            $result               = json_decode(fetch_url($request, 'json', '0'));
+            $result               = json_decode(fetch_url($request, 'json', 0));
             $sourceID             = str_replace('https://vimeo.com/', '', $result[0]->user_url);
             $data['feed']         = vimeo_get_feed($sourceID);
             $data['number_added'] = $vimeoModel->searchChannel($data['feed'], $videoID);

--- a/app/Helpers/aggro_helper.php
+++ b/app/Helpers/aggro_helper.php
@@ -14,7 +14,7 @@ if (! function_exists('decode_entities')) {
      * Handles double-encoded and triple-encoded entities common in RSS feeds
      * where content like `&amp;#8211;` needs to become `–`.
      *
-     * @param string $text Text that may contain encoded HTML entities
+     * @param string|null $text Text that may contain encoded HTML entities
      *
      * @return string Text with all HTML entities decoded
      */
@@ -64,8 +64,8 @@ if (! function_exists('clean_feed_cache')) {
     /**
      * Delete feed cache.
      *
-     * @return string
-     *                Count of deleted cache files.
+     * @return int
+     *             Count of deleted cache files.
      */
     function clean_feed_cache()
     {
@@ -111,8 +111,8 @@ if (! function_exists('fetch_error_logs')) {
     /**
      * Get error logs.
      *
-     * @return string
-     *                Error logs.
+     * @return list<string>
+     *                      Error logs.
      */
     function fetch_error_logs()
     {
@@ -206,6 +206,8 @@ if (! function_exists('fetch_thumbnail')) {
      * @param int|null &$httpStatus
      *                              Optional. Populated with the HTTP status code from the fetch.
      *
+     * @param-out int $httpStatus
+     *
      * @return bool
      *              Video thumbnail fetched and processed.
      */
@@ -268,13 +270,16 @@ if (! function_exists('fetch_url')) {
      *                              - text: return as text, no decoding.
      *                              - simplexml: return as decoded XML.
      *                              - json: return as decoded JSON.
-     * @param string   $spoof
-     *                              Spoof user agent string (1/0).
+     * @param int      $spoof
+     *                              Spoof user agent flag (1 = spoof, 0 = default).
      * @param int|null &$httpStatus
      *                              Optional. Populated with the HTTP response code.
      *
-     * @return string
-     *                Contents of requested url with optional decoding.
+     * @param-out int $httpStatus
+     *
+     * @return array|false|object|string
+     *                                   Decoded object/array for json, SimpleXMLElement for simplexml,
+     *                                   string for text, or false on error.
      */
     function fetch_url($url, $format = 'text', $spoof = 0, &$httpStatus = null)
     {
@@ -287,7 +292,7 @@ if (! function_exists('fetch_url')) {
         curl_setopt($fetch, CURLOPT_URL, $url);
         curl_setopt($fetch, CURLOPT_USERAGENT, $agent);
         curl_setopt($fetch, CURLOPT_CONNECTTIMEOUT, $storageConfig->urlConnectTimeout);
-        curl_setopt($fetch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($fetch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($fetch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($fetch, CURLOPT_MAXREDIRS, $storageConfig->urlMaxRedirects);
         $response   = curl_exec($fetch);

--- a/app/Helpers/vimeo_helper.php
+++ b/app/Helpers/vimeo_helper.php
@@ -11,8 +11,8 @@ if (! function_exists('vimeo_get_feed')) {
      * @param string $feedID
      *                       Channel ID.
      *
-     * @return object
-     *                JSON object.
+     * @return false|object
+     *                      JSON object, or false on error.
      *
      * @see fetchUrl()
      */
@@ -43,18 +43,18 @@ if (! function_exists('vimeo_id_from_url')) {
      * @param string $url
      *                    Full video URL.
      *
-     * @return string
-     *                Vimeo id from full URL.
+     * @return false|string
+     *                      Vimeo id from full URL, or false if not found.
      */
     function vimeo_id_from_url($url)
     {
         $pattern = '/vimeo\\.com\\/([0-9]{1,10})/';
-        if (preg_match($pattern, $url, $match) && isset($match[1])) {
+        if (preg_match($pattern, $url, $match)) {
             return $match[1];
         }
 
         $pattern = '/player\\.vimeo\\.com\\/video\\/([0-9]{1,10})/';
-        if (preg_match($pattern, $url, $match) && isset($match[1])) {
+        if (preg_match($pattern, $url, $match)) {
             return $match[1];
         }
 

--- a/app/Helpers/youtube_helper.php
+++ b/app/Helpers/youtube_helper.php
@@ -11,8 +11,8 @@ if (! function_exists('youtube_get_duration')) {
      * @param string $videoID
      *                        YouTube videoID.
      *
-     * @return string
-     *                Video duration.
+     * @return false|string
+     *                      Video duration, or false on error.
      */
     function youtube_get_duration($videoID)
     {
@@ -59,14 +59,9 @@ if (! function_exists('youtube_get_feed')) {
             $baseUrl = 'https://www.youtube.com/feeds/videos.xml?playlist_id=';
         }
 
-        $fetch  = $baseUrl . $feedID;
-        $result = fetch_feed($fetch, 1);
+        $fetch = $baseUrl . $feedID;
 
-        if ($result !== false && (is_array($result) || is_object($result))) {
-            return $result;
-        }
-
-        return false;
+        return fetch_feed($fetch, 1);
     }
 }
 
@@ -77,8 +72,8 @@ if (! function_exists('youtube_get_video_source')) {
      * @param string $videoID
      *                        YouTube videoID.
      *
-     * @return string
-     *                Video sourceID.
+     * @return false|string
+     *                      Video sourceID, or false on error.
      *
      * @see fetchUrl()
      */
@@ -90,7 +85,7 @@ if (! function_exists('youtube_get_video_source')) {
         $fetch  = 'https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D' . $videoID;
         $result = fetch_url($fetch, 'json', 0);
 
-        if ($result === false || ! (is_array($result) || is_object($result))) {
+        if (! is_object($result)) {
             return false;
         }
 
@@ -105,7 +100,7 @@ if (! function_exists('youtube_get_video_source')) {
             return false;
         }
 
-        if (preg_match($canonicalRegex, $channelResult, $matches) && isset($matches[1])) {
+        if (preg_match($canonicalRegex, $channelResult, $matches)) {
             return $matches[1];
         }
 
@@ -120,8 +115,8 @@ if (! function_exists('youtube_id_from_url')) {
      * @param string $url
      *                    Full video URL.
      *
-     * @return string
-     *                Youtube id from full URL.
+     * @return false|string
+     *                      Youtube id from full URL, or false if not found.
      */
     function youtube_id_from_url($url)
     {

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -5,5 +5,6 @@
  *
  * Defines CodeIgniter path constants that are set at runtime.
  */
-defined('FCPATH')   || define('FCPATH', __DIR__ . '/public/');
-defined('ROOTPATH') || define('ROOTPATH', __DIR__ . '/');
+defined('FCPATH')    || define('FCPATH', __DIR__ . '/public/');
+defined('ROOTPATH')  || define('ROOTPATH', __DIR__ . '/');
+defined('WRITEPATH') || define('WRITEPATH', __DIR__ . '/writable/');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,8 @@
 parameters:
     level: 5
+    # Pin analysis to the deploy target (DDEV container) so results are
+    # deterministic regardless of the host PHP used to invoke phpstan.
+    phpVersion: 80400
     bootstrapFiles:
         - phpstan-bootstrap.php
     scanDirectories:
@@ -17,14 +20,11 @@ parameters:
         - app/Views
     paths:
         - app/Controllers
+        - app/Helpers
         - app/Models
         - app/Repositories
         - app/Services
         - app/Views
-        # app/Helpers is intentionally scan-only (listed under scanDirectories
-        # above) rather than analysed. The helpers are procedural framework glue
-        # and produce ~53 pre-existing level-5 findings, mostly PHPDoc-certainty
-        # noise and SimplePie/CodeIgniter symbols phpstan cannot resolve.
     ignoreErrors:
         - '#Function base_url not found.#'
         - '#Function view not found.#'
@@ -32,6 +32,9 @@ parameters:
         - '#Function esc not found.#'
         - '#Function log_message not found.#'
         - '#Function clean_path not found.#'
+        - '#Function is_cli not found.#'
+        - '#Function csrf_token not found.#'
+        - '#Function csrf_hash not found.#'
         - '#Function lang not found.#'
         - '#Function config not found.#'
         - '#Function env not found.#'
@@ -39,7 +42,6 @@ parameters:
         - '#Variable \$this might not be defined.#'
         - '#Variable \$[a-zA-Z_][a-zA-Z0-9_]* might not be defined.#'
         - '#Strict comparison using === between .* and false will always evaluate to false.#'
-        - '#Strict comparison using !== between .* and false will always evaluate to true.#'
         - '#Right side of && is always true.#'
         - '#Calling static::.* outside of class scope.#'
         - '#Parameter .* of function str_pad expects string.*#'


### PR DESCRIPTION
## Summary

Moves `app/Helpers` from scan-only into PHPStan's analysed `paths`, so the helpers are checked at level 5 like the rest of `app/`. The `phpstan.neon` note claimed the ~53 findings were "PHPDoc-certainty noise"; in practice most were *inaccurate* docblocks, and correcting them resolves the bulk. The remainder are CodeIgniter/SimplePie framework symbols handled the same way the config already handles `base_url`/`view`/etc.

Net result: `app/Helpers` is fully analysed with **zero** suppressions added beyond three CodeIgniter globals.

## Changes

**Config / bootstrap**
- Pin `phpVersion: 80400` so analysis matches the DDEV/deploy target regardless of the host PHP used to invoke PHPStan.
- Define `WRITEPATH` in `phpstan-bootstrap.php`, alongside `FCPATH`/`ROOTPATH`.
- Ignore CI globals `is_cli`, `csrf_token`, `csrf_hash`; remove the now-stale `!== false always true` ignore pattern.

**`fetch_url` (root of the cascade)**
- `@param string $spoof` → `@param int $spoof` (it's a `0`/`1` flag).
- `@return string` → `@return array|false|object|string` (decoded JSON/XML, text, or `false` on error). This alone clears most impossible-type / always-true-false / unreachable findings in the Vimeo and YouTube helpers.
- `@param-out int $httpStatus` on `fetch_url` and `fetch_thumbnail`; `CURLOPT_RETURNTRANSFER` passed a bool.

**Other helper fixes**
- Correct return-type docblocks: `clean_feed_cache` (`int`), `fetch_error_logs` (`list<string>`), `vimeo_get_feed`/`vimeo_id_from_url`/`youtube_get_duration`/`youtube_get_video_source`/`youtube_id_from_url` (`false|…`), and `decode_entities` nullable input (SimplePie `get_title()` returns `?string`).
- Drop redundant `isset()` guards after `preg_match`, and the dead `is_array`/`is_object` guard in `youtube_get_feed` (`fetch_feed` always returns a SimplePie object — runtime behavior unchanged).
- Align `Aggro::add`'s `fetch_url` spoof argument with the corrected `int` type.

## Verification (all run in DDEV / PHP 8.4)

- `composer phpstan` — **No errors** (now analysing 43 files incl. helpers; was clean at 53 findings when helpers were merely added).
- `composer phpcs` — 0 errors, 0 warnings.
- `composer phpmd` — no mess detected.
- `php-cs-fixer --dry-run` — 0 files to fix.
- `phpunit` — 557 passing, 34 skipped (network/integration), 0 failures.

## Note (not addressed here)

`Aggro::add` does `json_decode(fetch_url($request, 'json', 0))` — but `fetch_url` already decodes JSON, so this double-decodes. Pre-existing, not flagged by PHPStan, and fixing it changes controller behavior, so it's left for a separate change.