### PR TITLE
Fix double JSON decode in Vimeo video fetch

### DIFF
--- a/app/Controllers/Aggro.php
+++ b/app/Controllers/Aggro.php
@@ -288,8 +288,15 @@ class Aggro extends BaseController
         }
 
         if (! $aggroModel->checkVideo($videoID)) {
-            $request              = 'https://vimeo.com/api/v2/video/' . $videoID . '.json';
-            $result               = json_decode(fetch_url($request, 'json', 0));
+            $request = 'https://vimeo.com/api/v2/video/' . $videoID . '.json';
+            $result  = fetch_url($request, 'json', 0);
+
+            if ($result === false || empty($result) || ! isset($result[0]->user_url)) {
+                log_message('error', 'Vimeo API returned no usable data for video ID: ' . $videoID);
+
+                return $this->response->setStatusCode(404);
+            }
+
             $sourceID             = str_replace('https://vimeo.com/', '', $result[0]->user_url);
             $data['feed']         = vimeo_get_feed($sourceID);
             $data['number_added'] = $vimeoModel->searchChannel($data['feed'], $videoID);


### PR DESCRIPTION
## Summary

`getVimeo()` (the single-video path) ran `json_decode()` on the result of `fetch_url($request, 'json', 0)`, but `fetch_url()` already decodes the response when called with the `'json'` format (`app/Helpers/aggro_helper.php:331-333`). The value was therefore decoded twice.

On PHP 8.4 this made the line broken in both directions:

- **Success:** `fetch_url()` returns the decoded `array(stdClass)`; `json_decode(array)` throws a `TypeError`.
- **Fetch failure:** `fetch_url()` returns `false`; `json_decode(false)` yields `null`, then `$result[0]->user_url` crashes.

It went unnoticed because no test or PHPStan run exercises the valid-video path (it needs a live Vimeo API call plus a DB miss).

## Changes

- Drop the redundant `json_decode()` so `$result` is the value `fetch_url()` already decoded.
- Guard against a `false`, empty, or malformed fetch result: log the failure and return a 404, instead of dereferencing a missing offset. This matches the method's existing 404-on-bad-input convention.

## Testing

- `composer test` — 557 passing, 0 failures (34 pre-existing network-dependent skips)
- `composer phpcs`, `composer phpstan`, `composer phpmd` — all clean

The valid-video path remains uncovered by automated tests as it requires the live Vimeo API; it follows the same network-skip pattern as the existing suite.