### PR TITLE
Update CodeIgniter framework to 4.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,33 @@ Maintenance tasks can be run via CLI using `ddev fire` for local or `ddev tunnel
 - `aggro vimeo/VIDEO_ID` — Fetch a Vimeo video
 - `aggro youtube/VIDEO_ID` — Fetch a YouTube video
 
+### Updating CodeIgniter
+
+Framework code lives in `vendor/` and updates through Composer, but the framework also ships skeleton files (`app/`, `public/`, `env`, `spark`) that are copies in this repo. When a release changes those files, [tatter/patches](https://github.com/tattersoftware/codeigniter4-patches) generates the diff and merges it into the project.
+
+1. Start from a clean working tree on a feature branch
+2. Run the patcher on the host, not in the container — `public/thumbs` is a DDEV bind mount, so the script's `rm -rf public/` always fails inside the container:
+   ```bash
+   vendor/bin/patch
+   ```
+3. Interpret the outcome:
+   - No skeleton changes — the script stops on the `tatter/scratch` branch with "nothing added to commit" (or an empty cherry-pick). There is nothing to reconcile; run the recovery steps below and move on
+   - Skeleton changes — the diff lands on the `tatter/patches` branch (resolve any conflict markers, then `git cherry-pick --continue`). Review it, merge it into your feature branch, and delete both `tatter/*` branches
+4. Update the framework itself:
+   ```bash
+   ddev composer update codeigniter4/framework
+   ```
+5. Verify with `ddev test` and `ddev check`
+
+The patcher never modifies your original branch. If it stops partway, recover with:
+
+```bash
+git checkout -f <your-branch>
+git clean -fd
+git branch -D tatter/scratch tatter/patches
+ddev composer install
+```
+
 ## Configuration
 
 ### Environment variables

--- a/composer.lock
+++ b/composer.lock
@@ -72,16 +72,16 @@
         },
         {
             "name": "codeigniter4/framework",
-            "version": "v4.7.3",
+            "version": "v4.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/codeigniter4/framework.git",
-                "reference": "ab9bf33caa3ccc25b1a4652234d7d0eb1d1937de"
+                "reference": "67ead895b7491703e5e5bc17436778806192008f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codeigniter4/framework/zipball/ab9bf33caa3ccc25b1a4652234d7d0eb1d1937de",
-                "reference": "ab9bf33caa3ccc25b1a4652234d7d0eb1d1937de",
+                "url": "https://api.github.com/repos/codeigniter4/framework/zipball/67ead895b7491703e5e5bc17436778806192008f",
+                "reference": "67ead895b7491703e5e5bc17436778806192008f",
                 "shasum": ""
             },
             "require": {
@@ -145,7 +145,7 @@
                 "slack": "https://codeigniterchat.slack.com",
                 "source": "https://github.com/codeigniter4/CodeIgniter4"
             },
-            "time": "2026-05-22T11:21:33+00:00"
+            "time": "2026-07-07T09:23:35+00:00"
         },
         {
             "name": "composer/pcre",


### PR DESCRIPTION
## Summary

- Updates codeigniter4/framework from 4.7.3 to 4.7.4, a security release covering trusted-proxy HTTPS detection, a `deleteBatch()` SQL injection fix, upload path traversal hardening, and stricter `is_image`/`mime_in` validation
- Documents the framework update workflow in the README, including how to run tatter/patches and recover from interrupted runs

## Notes

- Verified via `gh api repos/codeigniter4/framework/compare/v4.7.3...v4.7.4` that all 65 changed files are in `system/`; there are no changes to the skeleton files (`app/`, `public/`, `env`, `spark`), so no reconciliation outside `vendor/` is needed for this release
- tatter/patches must run on the host: `public/thumbs` is a DDEV bind mount (`upload_dirs`), so the script's `rm -rf public/` always fails inside the container

## Testing

- `ddev test` — 559 tests, 978 assertions, 0 failures (34 skipped for external services)
- `ddev composer lint` and `ddev composer phpstan` — clean
- `ddev check` — all local URLs return 200