### PR TITLE
Add slow play count refresh from public endpoints

### DIFF
--- a/.crontab
+++ b/.crontab
@@ -31,6 +31,10 @@ INDEX_PATH='/home/bmxfeed/aggro/current/public/index.php'
 ## Older video durations every day (at 1am)
 0 1 * * * $PHP_PATH $INDEX_PATH aggro duration
 
+## aggro plays
+## Refresh a batch of video play counts every 15 minutes
+*/15 * * * * $PHP_PATH $INDEX_PATH aggro plays
+
 ## aggro vimeo
 ## Look for new Vimeo videos every 7 minutes
 */7 * * * * $PHP_PATH $INDEX_PATH aggro vimeo

--- a/aggro-db.sql
+++ b/aggro-db.sql
@@ -73,8 +73,11 @@ CREATE TABLE `aggro_videos` (
   `flag_favorite` int(1) NOT NULL DEFAULT '0',
   `notes` text,
   `thumbnail_issue_count` int NOT NULL DEFAULT '0',
+  `plays_date_updated` datetime DEFAULT NULL,
+  `plays_issue_count` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`aggro_id`),
-  UNIQUE KEY `videoid` (`video_id`)
+  UNIQUE KEY `videoid` (`video_id`),
+  KEY `idx_video_plays_refresh` (`flag_bad`,`plays_date_updated`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -26,6 +26,7 @@ $routes->get('aggro/vimeo/(:segment)', 'Aggro::getVimeo/$1');
 $routes->get('aggro/youtube', 'Aggro::getYoutube');
 $routes->get('aggro/youtube/(:segment)', 'Aggro::getYoutube/$1');
 $routes->get('aggro/duration', 'Aggro::getYouTubeDuration');
+$routes->get('aggro/plays', 'Aggro::getPlays');
 $routes->post('aggro/log-clean', 'Aggro::getLogClean');
 $routes->post('aggro/log-error-clean', 'Aggro::getLogErrorClean');
 $routes->post('aggro/news-cache', 'Aggro::getNewsCache');
@@ -44,6 +45,7 @@ $routes->cli('aggro/vimeo/(:segment)', 'Aggro::getVimeo/$1');
 $routes->cli('aggro/youtube', 'Aggro::getYoutube');
 $routes->cli('aggro/youtube/(:segment)', 'Aggro::getYoutube/$1');
 $routes->cli('aggro/duration', 'Aggro::getYouTubeDuration');
+$routes->cli('aggro/plays', 'Aggro::getPlays');
 
 // Set 404 override
 $routes->set404Override('App\Controllers\Front::getError404');

--- a/app/Config/Storage.php
+++ b/app/Config/Storage.php
@@ -30,6 +30,14 @@ class Storage extends BaseConfig
     public int $minVideoDuration = 61; // seconds
 
     /**
+     * Play count refresh configuration.
+     */
+    public int $playsBatchSize = 10;
+
+    public int $playsIssueThreshold = 10;
+    public int $playsRequestDelay   = 1; // seconds between fetches
+
+    /**
      * Cache and network configuration.
      */
     public int $defaultCacheDuration = 1800; // 30 minutes

--- a/app/Controllers/Aggro.php
+++ b/app/Controllers/Aggro.php
@@ -9,6 +9,7 @@ use App\Models\VimeoModels;
 use App\Models\YoutubeModels;
 use App\Services\ChannelFetchService;
 use App\Services\FeedIngestionService;
+use App\Services\PlaysService;
 use CodeIgniter\CodeIgniter;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\I18n\Time;
@@ -226,6 +227,28 @@ class Aggro extends BaseController
         $flagged = $aggroModel->flagBrokenThumbnails();
         if ($flagged > 0) {
             echo "\n" . $flagged . " broken thumbnail(s) flagged.\n";
+        }
+
+        return true;
+    }
+
+    /**
+     * Refresh play counts for a batch of videos.
+     *
+     * Set cron to run every 15 minutes.
+     */
+    public function getPlays(): bool|ResponseInterface
+    {
+        helper('aggro');
+
+        if (! gate_check()) {
+            return $this->response->setStatusCode(403);
+        }
+
+        $playsService = new PlaysService();
+
+        if ($playsService->refreshPlays()) {
+            echo "\nPlay counts refreshed.\n";
         }
 
         return true;

--- a/app/Database/Migrations/2026-07-07-120000_AddPlaysRefreshColumns.php
+++ b/app/Database/Migrations/2026-07-07-120000_AddPlaysRefreshColumns.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddPlaysRefreshColumns extends Migration
+{
+    public function up()
+    {
+        $this->forge->addColumn('aggro_videos', [
+            'plays_date_updated' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'plays_issue_count' => [
+                'type'    => 'INT',
+                'null'    => false,
+                'default' => 0,
+            ],
+        ]);
+
+        $this->forge->addKey(['flag_bad', 'plays_date_updated'], false, false, 'idx_video_plays_refresh');
+        $this->forge->processIndexes('aggro_videos');
+    }
+
+    public function down()
+    {
+        $this->forge->dropKey('aggro_videos', 'idx_video_plays_refresh');
+        $this->forge->dropColumn('aggro_videos', 'plays_date_updated');
+        $this->forge->dropColumn('aggro_videos', 'plays_issue_count');
+    }
+}

--- a/app/Helpers/vimeo_helper.php
+++ b/app/Helpers/vimeo_helper.php
@@ -36,6 +36,35 @@ if (! function_exists('vimeo_get_feed')) {
     }
 }
 
+if (! function_exists('vimeo_get_plays')) {
+    /**
+     * Fetch Vimeo video play count.
+     *
+     * @param string $videoID
+     *                        Vimeo videoID.
+     *
+     * @return false|string|null
+     *                           Play count, null when the owner hides stats, or false on error.
+     */
+    function vimeo_get_plays($videoID)
+    {
+        helper('aggro');
+
+        $fetch  = 'https://vimeo.com/api/v2/video/' . $videoID . '.json';
+        $result = fetch_url($fetch, 'json', 0);
+
+        if ($result === false || ! is_array($result) || ! isset($result[0]) || ! is_object($result[0])) {
+            return false;
+        }
+
+        if (! isset($result[0]->stats_number_of_plays)) {
+            return null;
+        }
+
+        return (string) $result[0]->stats_number_of_plays;
+    }
+}
+
 if (! function_exists('vimeo_id_from_url')) {
     /**
      * Parse vimeo video id from full URL.

--- a/app/Helpers/youtube_helper.php
+++ b/app/Helpers/youtube_helper.php
@@ -33,6 +33,33 @@ if (! function_exists('youtube_get_duration')) {
     }
 }
 
+if (! function_exists('youtube_get_plays')) {
+    /**
+     * Fetch YouTube video play count.
+     *
+     * @param string $videoID
+     *                        YouTube videoID.
+     *
+     * @return false|string
+     *                      Play count, or false on error.
+     */
+    function youtube_get_plays($videoID)
+    {
+        helper('aggro');
+
+        $videoPage  = 'https://www.youtube.com/watch?v=' . $videoID;
+        $resultPage = fetch_url($videoPage, 'text', 0);
+
+        if ($resultPage !== false && is_string($resultPage)) {
+            if (preg_match('/"viewCount":"(\d+)"/', $resultPage, $matches)) {
+                return $matches[1];
+            }
+        }
+
+        return false;
+    }
+}
+
 if (! function_exists('youtube_get_feed')) {
     /**
      * Fetch YouTube channel feed.
@@ -178,6 +205,26 @@ if (! function_exists('youtube_get_dimensions')) {
     }
 }
 
+if (! function_exists('youtube_parse_plays')) {
+    /**
+     * Parse play count from a YouTube feed item.
+     *
+     * @return false|string
+     *                      Play count, or false when statistics are absent.
+     */
+    function youtube_parse_plays(object $item)
+    {
+        $group = $item->get_item_tags(SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'group');
+        $views = $group[0]['child'][SimplePie\SimplePie::NAMESPACE_MEDIARSS]['community'][0]['child'][SimplePie\SimplePie::NAMESPACE_MEDIARSS]['statistics'][0]['attribs']['']['views'] ?? null;
+
+        if ($views === null) {
+            return false;
+        }
+
+        return $views;
+    }
+}
+
 if (! function_exists('youtube_parse_meta')) {
     /**
      * Parse youtube video metadata for DB import.
@@ -204,11 +251,12 @@ if (! function_exists('youtube_parse_meta')) {
         if ($video['video_date_uploaded'] <= $archive) {
             $video['flag_archive'] = 1;
         }
-        $video['video_title']           = $item->get_title();
+        $video['video_title'] = $item->get_title();
+        $video['video_plays'] = youtube_parse_plays($item);
+        if ($video['video_plays'] === false) {
+            $video['video_plays'] = 0;
+        }
         $group                          = $item->get_item_tags(SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'group');
-        $community                      = $group[0]['child'][SimplePie\SimplePie::NAMESPACE_MEDIARSS]['community'];
-        $statistics                     = $community[0]['child'][SimplePie\SimplePie::NAMESPACE_MEDIARSS]['statistics'];
-        $video['video_plays']           = $statistics[0]['attribs']['']['views'];
         $thumbnail                      = $group[0]['child'][SimplePie\SimplePie::NAMESPACE_MEDIARSS]['thumbnail'];
         $video['video_thumbnail_url']   = $thumbnail[0]['attribs']['']['url'];
         $channelID                      = $item->get_item_tags('http://www.youtube.com/xml/schemas/2015', 'channelId');

--- a/app/Models/AggroModels.php
+++ b/app/Models/AggroModels.php
@@ -165,6 +165,22 @@ class AggroModels extends Model
     }
 
     /**
+     * Set play count for a video.
+     *
+     * @param string $videoId
+     *                        Video id.
+     * @param int    $plays
+     *                        Play count.
+     *
+     * @return bool
+     *              Play count written.
+     */
+    public function setVideoPlays($videoId, $plays)
+    {
+        return $this->videoRepository->updateVideoPlays($videoId, $plays);
+    }
+
+    /**
      * Update video source last fetch timestamp.
      *
      * @param string $sourceSlug

--- a/app/Models/VimeoModels.php
+++ b/app/Models/VimeoModels.php
@@ -93,7 +93,11 @@ class VimeoModels extends Model
                 $video = vimeo_parse_meta($item);
                 $this->aggroModel->addVideo($video);
                 $addCount++;
+
+                continue;
             }
+
+            $this->updateExistingVideoPlays($item);
         }
 
         if ($addCount >= 1) {
@@ -102,5 +106,22 @@ class VimeoModels extends Model
         }
 
         return $addCount;
+    }
+
+    /**
+     * Refresh stored play count for an existing video from feed data.
+     *
+     * Vimeo owners can hide stats; without the field no update happens.
+     *
+     * @param object $item
+     *                     Feed item.
+     *
+     * @return void
+     */
+    private function updateExistingVideoPlays($item)
+    {
+        if (isset($item->stats_number_of_plays)) {
+            $this->aggroModel->setVideoPlays($item->id, (int) $item->stats_number_of_plays);
+        }
     }
 }

--- a/app/Models/YoutubeModels.php
+++ b/app/Models/YoutubeModels.php
@@ -71,6 +71,13 @@ class YoutubeModels extends Model
                 $video = youtube_parse_meta($item);
                 $this->aggroModel->addVideo($video);
                 $addCount++;
+
+                continue;
+            }
+
+            $plays = youtube_parse_plays($item);
+            if ($plays !== false) {
+                $this->aggroModel->setVideoPlays($currentVideoId, (int) $plays);
             }
         }
 

--- a/app/Repositories/VideoRepository.php
+++ b/app/Repositories/VideoRepository.php
@@ -259,6 +259,120 @@ class VideoRepository
     }
 
     /**
+     * Get videos due for a play count refresh.
+     *
+     * Never-refreshed videos come first, then oldest refresh. Archived
+     * videos are included so the whole table cycles over time.
+     *
+     * @param int $limit
+     *                   Batch size.
+     *
+     * @return array
+     *               Video rows with video_id and video_type.
+     */
+    public function getVideosForPlaysRefresh($limit = 10)
+    {
+        $query = $this->db->table('aggro_videos')
+            ->select('video_id, video_type')
+            ->where('flag_bad', 0)
+            ->orderBy('plays_date_updated', 'ASC')
+            ->limit((int) $limit)
+            ->get();
+
+        return $query->getResult();
+    }
+
+    /**
+     * Update play count for a video.
+     *
+     * A zero or negative count never overwrites a stored count; the
+     * refresh timestamp is still stamped so the batch cursor advances.
+     *
+     * @param string $videoId
+     *                        Video id.
+     * @param int    $plays
+     *                        Play count.
+     *
+     * @return bool
+     *              Play count written.
+     */
+    public function updateVideoPlays($videoId, $plays)
+    {
+        if ((int) $plays <= 0) {
+            $this->stampPlaysChecked($videoId);
+
+            return false;
+        }
+
+        $this->db->table('aggro_videos')
+            ->where('video_id', $videoId)
+            ->update([
+                'video_plays'        => (int) $plays,
+                'plays_date_updated' => date('Y-m-d H:i:s'),
+                'plays_issue_count'  => 0,
+            ]);
+
+        return true;
+    }
+
+    /**
+     * Stamp a video as checked for plays without changing the count.
+     *
+     * @param string $videoId
+     *                        Video id.
+     */
+    public function stampPlaysChecked($videoId)
+    {
+        $this->db->table('aggro_videos')
+            ->where('video_id', $videoId)
+            ->update([
+                'plays_date_updated' => date('Y-m-d H:i:s'),
+                'plays_issue_count'  => 0,
+            ]);
+    }
+
+    /**
+     * Record a failed play count fetch for a video.
+     *
+     * Videos failing more times than the configured threshold are
+     * permanently flagged bad, mirroring the thumbnail issue pattern.
+     *
+     * @param string $videoId
+     *                        Video id.
+     *
+     * @return bool
+     *              Video flagged bad.
+     */
+    public function recordPlaysIssue($videoId)
+    {
+        $storageConfig = config('Storage');
+
+        $this->db->table('aggro_videos')
+            ->where('video_id', $videoId)
+            ->set('plays_issue_count', 'plays_issue_count + 1', false)
+            ->set('plays_date_updated', date('Y-m-d H:i:s'))
+            ->update();
+
+        $video = $this->db->table('aggro_videos')
+            ->select('plays_issue_count')
+            ->where('video_id', $videoId)
+            ->get()
+            ->getRow();
+
+        if ($video === null || (int) $video->plays_issue_count <= $storageConfig->playsIssueThreshold) {
+            return false;
+        }
+
+        $this->db->table('aggro_videos')
+            ->where('video_id', $videoId)
+            ->update(['flag_bad' => 1]);
+
+        log_message('error', 'Flagged video ' . $videoId . ' as bad — play count fetch failure count exceeded threshold (' . $storageConfig->playsIssueThreshold . ').');
+
+        return true;
+    }
+
+    /**
      * Get single video.
      *
      * @param string $slug

--- a/app/Services/PlaysService.php
+++ b/app/Services/PlaysService.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\UtilityModels;
+use App\Repositories\VideoRepository;
+
+/**
+ * Service for refreshing video play counts from public endpoints.
+ */
+class PlaysService
+{
+    protected $videoRepository;
+    protected $utilityModel;
+
+    public function __construct(?VideoRepository $videoRepository = null, ?UtilityModels $utilityModel = null)
+    {
+        $this->videoRepository = $videoRepository ?? new VideoRepository();
+        $this->utilityModel    = $utilityModel ?? new UtilityModels();
+    }
+
+    /**
+     * Refresh play counts for a batch of videos.
+     *
+     * Videos are processed oldest-refresh-first so the whole table,
+     * including archived videos, cycles over time. Requests are spaced
+     * out to stay polite to the public endpoints.
+     *
+     * @return bool
+     *              Refresh batch complete.
+     *
+     * @see sendLog()
+     */
+    public function refreshPlays()
+    {
+        helper(['aggro', 'youtube', 'vimeo']);
+
+        $storageConfig = config('Storage');
+        $videos        = $this->videoRepository->getVideosForPlaysRefresh($storageConfig->playsBatchSize);
+        $updateCount   = 0;
+
+        foreach ($videos as $index => $video) {
+            if ($index > 0 && $storageConfig->playsRequestDelay > 0) {
+                sleep($storageConfig->playsRequestDelay);
+            }
+
+            $plays = $this->fetchPlays($video);
+
+            if ($plays === false) {
+                $this->videoRepository->recordPlaysIssue($video->video_id);
+
+                continue;
+            }
+
+            if ($plays === null) {
+                $this->videoRepository->stampPlaysChecked($video->video_id);
+
+                continue;
+            }
+
+            if ($this->videoRepository->updateVideoPlays($video->video_id, $plays)) {
+                $updateCount++;
+            }
+        }
+
+        $message = $updateCount . ' video play counts updated.';
+        $this->utilityModel->sendLog($message);
+
+        return true;
+    }
+
+    /**
+     * Fetch the current play count for a video from its public endpoint.
+     *
+     * @param object $video
+     *                      Row with video_id and video_type.
+     *
+     * @return false|int|null
+     *                        Play count, null when the source hides stats, or false on fetch failure.
+     */
+    protected function fetchPlays(object $video)
+    {
+        if ($video->video_type === 'vimeo') {
+            return $this->normalizePlays(vimeo_get_plays($video->video_id));
+        }
+
+        return $this->normalizePlays(youtube_get_plays($video->video_id));
+    }
+
+    /**
+     * Cast a helper play count to int while preserving failure states.
+     *
+     * @param false|string|null $plays
+     *                                 Raw helper return value.
+     *
+     * @return false|int|null
+     *                        Play count, null when the source hides stats, or false on fetch failure.
+     */
+    private function normalizePlays($plays)
+    {
+        if ($plays === false || $plays === null) {
+            return $plays;
+        }
+
+        return (int) $plays;
+    }
+}

--- a/tests/_support/Database/Migrations/20240101000001_CreateTestTables.php
+++ b/tests/_support/Database/Migrations/20240101000001_CreateTestTables.php
@@ -117,6 +117,15 @@ class CreateTestTables extends Migration
                 'null'    => false,
                 'default' => 0,
             ],
+            'plays_date_updated' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'plays_issue_count' => [
+                'type'    => 'INT',
+                'null'    => false,
+                'default' => 0,
+            ],
         ]);
         $this->forge->addKey('aggro_id', true);
         $this->forge->addUniqueKey('video_id');

--- a/tests/unit/AggroControllerTest.php
+++ b/tests/unit/AggroControllerTest.php
@@ -225,6 +225,20 @@ final class AggroControllerTest extends DatabaseTestCase
         $this->assertTrue($result->isOK() || $result->response()->getStatusCode() === 200);
     }
 
+    public function testGetPlaysMethodExists(): void
+    {
+        $this->assertTrue(method_exists($this->aggroController, 'getPlays'));
+    }
+
+    public function testGetPlaysExecutesSuccessfully(): void
+    {
+        // In CLI mode gate_check() returns true
+        $result = $this->controller(Aggro::class)
+            ->execute('getPlays');
+
+        $this->assertTrue($result->isOK() || $result->response()->getStatusCode() === 200);
+    }
+
     public function testGetVimeoWithNullVideoIdExecutes(): void
     {
         // In CLI mode gate_check() returns true, null videoID fetches channels

--- a/tests/unit/PlaysServiceTest.php
+++ b/tests/unit/PlaysServiceTest.php
@@ -1,0 +1,295 @@
+<?php
+
+use App\Models\UtilityModels;
+use App\Services\PlaysService;
+use Config\Storage;
+use Tests\Support\ServiceTestCase;
+
+/**
+ * @internal
+ */
+final class PlaysServiceTest extends ServiceTestCase
+{
+    private PlaysService $service;
+    private Storage $storageConfig;
+    private int $originalBatchSize;
+    private int $originalDelay;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->storageConfig                    = config('Storage');
+        $this->originalBatchSize                = $this->storageConfig->playsBatchSize;
+        $this->originalDelay                    = $this->storageConfig->playsRequestDelay;
+        $this->storageConfig->playsRequestDelay = 0;
+
+        $this->service = $this->buildServiceWithCannedResponses();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->storageConfig->playsBatchSize    = $this->originalBatchSize;
+        $this->storageConfig->playsRequestDelay = $this->originalDelay;
+        parent::tearDown();
+    }
+
+    /**
+     * Build a PlaysService whose fetchPlays() returns canned responses
+     * keyed by video_id instead of hitting YouTube/Vimeo.
+     *
+     * @param UtilityModels|null $utilityModel Optional utility model override
+     */
+    private function buildServiceWithCannedResponses(?UtilityModels $utilityModel = null): PlaysService
+    {
+        return new class (null, $utilityModel) extends PlaysService {
+            public array $responses = [];
+
+            protected function fetchPlays(object $video)
+            {
+                if (! array_key_exists($video->video_id, $this->responses)) {
+                    return false;
+                }
+
+                return $this->responses[$video->video_id];
+            }
+        };
+    }
+
+    /**
+     * Build a test video row.
+     *
+     * @param array $overrides Optional data to override defaults
+     */
+    private function makeVideo(array $overrides = []): array
+    {
+        $defaults = [
+            'video_id'              => 'test_' . uniqid(),
+            'aggro_date_added'      => date('Y-m-d H:i:s'),
+            'aggro_date_updated'    => date('Y-m-d H:i:s'),
+            'video_date_uploaded'   => date('Y-m-d H:i:s'),
+            'flag_archive'          => 0,
+            'flag_bad'              => 0,
+            'video_plays'           => 100,
+            'video_title'           => 'Test Video',
+            'video_thumbnail_url'   => 'https://example.com/thumb.jpg',
+            'video_width'           => 1920,
+            'video_height'          => 1080,
+            'video_aspect_ratio'    => '16:9',
+            'video_duration'        => 300,
+            'video_source_id'       => 'test_source',
+            'video_source_username' => 'testuser',
+            'video_source_url'      => 'https://example.com/video',
+            'video_type'            => 'youtube',
+        ];
+
+        return array_merge($defaults, $overrides);
+    }
+
+    /**
+     * Fetch a video row by video_id.
+     */
+    private function getVideoRow(string $videoId): array
+    {
+        return $this->db->table('aggro_videos')
+            ->where('video_id', $videoId)
+            ->get()
+            ->getRowArray();
+    }
+
+    public function testRefreshPlaysUpdatesPlayCounts()
+    {
+        // Arrange
+        $this->insertTestVideo($this->makeVideo(['video_id' => 'yt_video', 'video_type' => 'youtube']));
+        $this->insertTestVideo($this->makeVideo(['video_id' => 'vimeo_video', 'video_type' => 'vimeo']));
+
+        $this->service->responses = [
+            'yt_video'    => 5000,
+            'vimeo_video' => 250,
+        ];
+
+        // Act
+        $result = $this->service->refreshPlays();
+
+        // Assert
+        $this->assertTrue($result);
+
+        $ytRow = $this->getVideoRow('yt_video');
+        $this->assertSame(5000, (int) $ytRow['video_plays']);
+        $this->assertNotNull($ytRow['plays_date_updated']);
+        $this->assertSame(0, (int) $ytRow['plays_issue_count']);
+
+        $vimeoRow = $this->getVideoRow('vimeo_video');
+        $this->assertSame(250, (int) $vimeoRow['video_plays']);
+        $this->assertNotNull($vimeoRow['plays_date_updated']);
+    }
+
+    public function testRefreshPlaysStampsWithoutOverwritingWhenStatsHidden()
+    {
+        // Arrange - Vimeo owners can hide play stats; null means checked but unavailable
+        $this->insertTestVideo($this->makeVideo([
+            'video_id'    => 'hidden_stats',
+            'video_type'  => 'vimeo',
+            'video_plays' => 750,
+        ]));
+
+        $this->service->responses = ['hidden_stats' => null];
+
+        // Act
+        $this->service->refreshPlays();
+
+        // Assert
+        $row = $this->getVideoRow('hidden_stats');
+        $this->assertSame(750, (int) $row['video_plays']);
+        $this->assertNotNull($row['plays_date_updated']);
+        $this->assertSame(0, (int) $row['plays_issue_count']);
+    }
+
+    public function testRefreshPlaysRecordsIssueOnFetchFailure()
+    {
+        // Arrange
+        $this->insertTestVideo($this->makeVideo([
+            'video_id'    => 'gone_video',
+            'video_plays' => 900,
+        ]));
+
+        $this->service->responses = ['gone_video' => false];
+
+        // Act
+        $this->service->refreshPlays();
+
+        // Assert - Plays untouched, issue recorded, cursor still advances
+        $row = $this->getVideoRow('gone_video');
+        $this->assertSame(900, (int) $row['video_plays']);
+        $this->assertSame(1, (int) $row['plays_issue_count']);
+        $this->assertNotNull($row['plays_date_updated']);
+        $this->assertSame(0, (int) $row['flag_bad']);
+    }
+
+    public function testRefreshPlaysDoesNotOverwriteWithZero()
+    {
+        // Arrange
+        $this->insertTestVideo($this->makeVideo([
+            'video_id'    => 'zero_response',
+            'video_plays' => 1200,
+        ]));
+
+        $this->service->responses = ['zero_response' => 0];
+
+        // Act
+        $this->service->refreshPlays();
+
+        // Assert - A real count is never clobbered by zero
+        $row = $this->getVideoRow('zero_response');
+        $this->assertSame(1200, (int) $row['video_plays']);
+        $this->assertNotNull($row['plays_date_updated']);
+    }
+
+    public function testRefreshPlaysSkipsBadVideos()
+    {
+        // Arrange
+        $this->insertTestVideo($this->makeVideo([
+            'video_id' => 'bad_video',
+            'flag_bad' => 1,
+        ]));
+
+        $this->service->responses = ['bad_video' => 999];
+
+        // Act
+        $this->service->refreshPlays();
+
+        // Assert
+        $row = $this->getVideoRow('bad_video');
+        $this->assertSame(100, (int) $row['video_plays']);
+        $this->assertNull($row['plays_date_updated']);
+    }
+
+    public function testRefreshPlaysIncludesArchivedVideos()
+    {
+        // Arrange - Archived videos are the whole point of the refresher
+        $this->insertTestVideo($this->makeVideo([
+            'video_id'     => 'archived_video',
+            'flag_archive' => 1,
+        ]));
+
+        $this->service->responses = ['archived_video' => 800];
+
+        // Act
+        $this->service->refreshPlays();
+
+        // Assert
+        $row = $this->getVideoRow('archived_video');
+        $this->assertSame(800, (int) $row['video_plays']);
+        $this->assertNotNull($row['plays_date_updated']);
+    }
+
+    public function testRefreshPlaysRespectsBatchSize()
+    {
+        // Arrange
+        $this->storageConfig->playsBatchSize = 2;
+
+        $this->insertTestVideo($this->makeVideo(['video_id' => 'batch_one']));
+        $this->insertTestVideo($this->makeVideo(['video_id' => 'batch_two']));
+        $this->insertTestVideo($this->makeVideo(['video_id' => 'batch_three']));
+
+        $this->service->responses = [
+            'batch_one'   => 10,
+            'batch_two'   => 20,
+            'batch_three' => 30,
+        ];
+
+        // Act
+        $this->service->refreshPlays();
+
+        // Assert - Only batch-size videos processed
+        $processed = $this->db->table('aggro_videos')
+            ->where('plays_date_updated IS NOT NULL')
+            ->countAllResults();
+        $this->assertSame(2, $processed);
+    }
+
+    public function testRefreshPlaysFlagsBadAfterRepeatedFailures()
+    {
+        // Arrange - Already at the threshold; one more failure tips it over
+        $this->insertTestVideo($this->makeVideo([
+            'video_id'          => 'chronic_failure',
+            'plays_issue_count' => 10,
+        ]));
+
+        $this->service->responses = ['chronic_failure' => false];
+
+        // Act
+        $this->service->refreshPlays();
+
+        // Assert
+        $row = $this->getVideoRow('chronic_failure');
+        $this->assertSame(11, (int) $row['plays_issue_count']);
+        $this->assertSame(1, (int) $row['flag_bad']);
+    }
+
+    public function testRefreshPlaysHandlesEmptyDatabase()
+    {
+        // Act
+        $result = $this->service->refreshPlays();
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testRefreshPlaysLogsUpdateCount()
+    {
+        // Arrange
+        $mockUtility = $this->createMock(UtilityModels::class);
+        $mockUtility->expects($this->once())
+            ->method('sendLog')
+            ->with($this->stringContains('play counts updated'));
+
+        $service            = $this->buildServiceWithCannedResponses($mockUtility);
+        $service->responses = ['logged_video' => 42];
+
+        $this->insertTestVideo($this->makeVideo(['video_id' => 'logged_video']));
+
+        // Act
+        $service->refreshPlays();
+    }
+}

--- a/tests/unit/VideoRepositoryTest.php
+++ b/tests/unit/VideoRepositoryTest.php
@@ -167,4 +167,189 @@ final class VideoRepositoryTest extends RepositoryTestCase
 
         $this->assertCount(2, $yearResults);
     }
+
+    public function testGetVideosForPlaysRefreshOrdersNeverRefreshedFirst()
+    {
+        // Arrange
+        $neverRefreshed = $this->createTestVideo([
+            'video_id'           => 'never_refreshed',
+            'plays_date_updated' => null,
+        ]);
+        $refreshedOld = $this->createTestVideo([
+            'video_id'           => 'refreshed_old',
+            'plays_date_updated' => date('Y-m-d H:i:s', strtotime('-10 days')),
+        ]);
+        $refreshedRecent = $this->createTestVideo([
+            'video_id'           => 'refreshed_recent',
+            'plays_date_updated' => date('Y-m-d H:i:s', strtotime('-1 day')),
+        ]);
+
+        $this->db->table('aggro_videos')->insertBatch([$refreshedRecent, $refreshedOld, $neverRefreshed]);
+
+        // Act
+        $results = $this->repository->getVideosForPlaysRefresh(2);
+
+        // Assert - Never-refreshed first, then oldest refresh
+        $this->assertCount(2, $results);
+        $this->assertSame('never_refreshed', $results[0]->video_id);
+        $this->assertSame('refreshed_old', $results[1]->video_id);
+    }
+
+    public function testGetVideosForPlaysRefreshExcludesBadVideos()
+    {
+        // Arrange
+        $badVideo = $this->createTestVideo([
+            'video_id' => 'bad_video',
+            'flag_bad' => 1,
+        ]);
+        $goodVideo = $this->createTestVideo([
+            'video_id' => 'good_video',
+            'flag_bad' => 0,
+        ]);
+
+        $this->db->table('aggro_videos')->insertBatch([$badVideo, $goodVideo]);
+
+        // Act
+        $results = $this->repository->getVideosForPlaysRefresh(10);
+
+        // Assert
+        $this->assertCount(1, $results);
+        $this->assertSame('good_video', $results[0]->video_id);
+    }
+
+    public function testGetVideosForPlaysRefreshIncludesArchivedVideos()
+    {
+        // Arrange
+        $archivedVideo = $this->createTestVideo([
+            'video_id'     => 'archived_video',
+            'flag_archive' => 1,
+        ]);
+
+        $this->db->table('aggro_videos')->insert($archivedVideo);
+
+        // Act
+        $results = $this->repository->getVideosForPlaysRefresh(10);
+
+        // Assert
+        $this->assertCount(1, $results);
+        $this->assertSame('archived_video', $results[0]->video_id);
+    }
+
+    public function testUpdateVideoPlaysWritesCountAndResetsIssues()
+    {
+        // Arrange
+        $video = $this->createTestVideo([
+            'video_id'          => 'update_me',
+            'video_plays'       => 100,
+            'plays_issue_count' => 3,
+        ]);
+        $this->db->table('aggro_videos')->insert($video);
+
+        // Act
+        $result = $this->repository->updateVideoPlays('update_me', 5000);
+
+        // Assert
+        $this->assertTrue($result);
+
+        $row = $this->db->table('aggro_videos')->where('video_id', 'update_me')->get()->getRowArray();
+        $this->assertSame(5000, (int) $row['video_plays']);
+        $this->assertSame(0, (int) $row['plays_issue_count']);
+        $this->assertNotNull($row['plays_date_updated']);
+    }
+
+    public function testUpdateVideoPlaysIgnoresZeroAndStamps()
+    {
+        // Arrange
+        $video = $this->createTestVideo([
+            'video_id'    => 'keep_plays',
+            'video_plays' => 800,
+        ]);
+        $this->db->table('aggro_videos')->insert($video);
+
+        // Act
+        $result = $this->repository->updateVideoPlays('keep_plays', 0);
+
+        // Assert - Zero never clobbers a real count, but the cursor advances
+        $this->assertFalse($result);
+
+        $row = $this->db->table('aggro_videos')->where('video_id', 'keep_plays')->get()->getRowArray();
+        $this->assertSame(800, (int) $row['video_plays']);
+        $this->assertNotNull($row['plays_date_updated']);
+    }
+
+    public function testStampPlaysCheckedSetsDateOnly()
+    {
+        // Arrange
+        $video = $this->createTestVideo([
+            'video_id'    => 'stamp_me',
+            'video_plays' => 600,
+        ]);
+        $this->db->table('aggro_videos')->insert($video);
+
+        // Act
+        $this->repository->stampPlaysChecked('stamp_me');
+
+        // Assert
+        $row = $this->db->table('aggro_videos')->where('video_id', 'stamp_me')->get()->getRowArray();
+        $this->assertSame(600, (int) $row['video_plays']);
+        $this->assertNotNull($row['plays_date_updated']);
+    }
+
+    public function testRecordPlaysIssueIncrementsCountAndStamps()
+    {
+        // Arrange
+        $video = $this->createTestVideo(['video_id' => 'issue_video']);
+        $this->db->table('aggro_videos')->insert($video);
+
+        // Act
+        $flagged = $this->repository->recordPlaysIssue('issue_video');
+
+        // Assert
+        $this->assertFalse($flagged);
+
+        $row = $this->db->table('aggro_videos')->where('video_id', 'issue_video')->get()->getRowArray();
+        $this->assertSame(1, (int) $row['plays_issue_count']);
+        $this->assertSame(0, (int) $row['flag_bad']);
+        $this->assertNotNull($row['plays_date_updated']);
+    }
+
+    public function testRecordPlaysIssueFlagsBadOverThreshold()
+    {
+        // Arrange - Already at the threshold; one more failure tips it over
+        $video = $this->createTestVideo([
+            'video_id'          => 'chronic_video',
+            'plays_issue_count' => 10,
+        ]);
+        $this->db->table('aggro_videos')->insert($video);
+
+        // Act
+        $flagged = $this->repository->recordPlaysIssue('chronic_video');
+
+        // Assert
+        $this->assertTrue($flagged);
+
+        $row = $this->db->table('aggro_videos')->where('video_id', 'chronic_video')->get()->getRowArray();
+        $this->assertSame(11, (int) $row['plays_issue_count']);
+        $this->assertSame(1, (int) $row['flag_bad']);
+    }
+
+    public function testRecordPlaysIssueDoesNotFlagAtThreshold()
+    {
+        // Arrange
+        $video = $this->createTestVideo([
+            'video_id'          => 'borderline_video',
+            'plays_issue_count' => 9,
+        ]);
+        $this->db->table('aggro_videos')->insert($video);
+
+        // Act
+        $flagged = $this->repository->recordPlaysIssue('borderline_video');
+
+        // Assert - Count reaches the threshold but does not exceed it
+        $this->assertFalse($flagged);
+
+        $row = $this->db->table('aggro_videos')->where('video_id', 'borderline_video')->get()->getRowArray();
+        $this->assertSame(10, (int) $row['plays_issue_count']);
+        $this->assertSame(0, (int) $row['flag_bad']);
+    }
 }

--- a/tests/unit/VimeoModelsTest.php
+++ b/tests/unit/VimeoModelsTest.php
@@ -218,4 +218,44 @@ final class VimeoModelsTest extends DatabaseTestCase
         $result = $model->parseChannel([]);
         $this->assertSame(0, $result);
     }
+
+    public function testParseChannelUpdatesPlaysForExistingVideo(): void
+    {
+        // Existing videos get their play counts refreshed from the feed
+        $mockAggro = $this->createMock(AggroModels::class);
+        $mockAggro->method('checkVideo')->willReturn(true);
+        $mockAggro->expects($this->once())
+            ->method('setVideoPlays')
+            ->with('existing_video_id', 4321);
+
+        $mockUtility = $this->createMock(UtilityModels::class);
+
+        $model = new VimeoModels($mockAggro, $mockUtility);
+
+        $feed = [
+            (object) ['id' => 'existing_video_id', 'stats_number_of_plays' => 4321],
+        ];
+
+        $result = $model->parseChannel($feed);
+        $this->assertSame(0, $result);
+    }
+
+    public function testParseChannelSkipsPlaysUpdateWhenStatsHidden(): void
+    {
+        // Vimeo owners can hide stats; no update should happen without the field
+        $mockAggro = $this->createMock(AggroModels::class);
+        $mockAggro->method('checkVideo')->willReturn(true);
+        $mockAggro->expects($this->never())->method('setVideoPlays');
+
+        $mockUtility = $this->createMock(UtilityModels::class);
+
+        $model = new VimeoModels($mockAggro, $mockUtility);
+
+        $feed = [
+            (object) ['id' => 'existing_video_id', 'title' => 'Hidden Stats Video'],
+        ];
+
+        $result = $model->parseChannel($feed);
+        $this->assertSame(0, $result);
+    }
 }

--- a/tests/unit/YoutubeModelsTest.php
+++ b/tests/unit/YoutubeModelsTest.php
@@ -7,6 +7,7 @@ use App\Models\UtilityModels;
 use App\Models\YoutubeModels;
 use CodeIgniter\Model;
 use ReflectionClass;
+use SimplePie\SimplePie;
 use Tests\Support\DatabaseTestCase;
 
 /**
@@ -259,6 +260,99 @@ final class YoutubeModelsTest extends DatabaseTestCase
             public function get_items($start = 0, $end = 0): array
             {
                 return [];
+            }
+        };
+
+        $result = $model->parseChannel($mockFeed);
+        $this->assertSame(0, $result);
+    }
+
+    public function testParseChannelUpdatesPlaysForExistingVideo(): void
+    {
+        // Existing videos get their play counts refreshed from the feed
+        $mockAggro = $this->createMock(AggroModels::class);
+        $mockAggro->method('checkVideo')->willReturn(true);
+        $mockAggro->expects($this->once())
+            ->method('setVideoPlays')
+            ->with('existing_video_id', 12345);
+
+        $mockUtility = $this->createMock(UtilityModels::class);
+
+        $model = new YoutubeModels($mockAggro, $mockUtility);
+
+        $mockItem = new class () {
+            public function get_item_tags($namespace, $tag): array
+            {
+                if ($tag === 'videoId') {
+                    return [['data' => 'existing_video_id']];
+                }
+
+                // media:group carrying media:community > media:statistics views
+                return [[
+                    'child' => [
+                        SimplePie::NAMESPACE_MEDIARSS => [
+                            'community' => [[
+                                'child' => [
+                                    SimplePie::NAMESPACE_MEDIARSS => [
+                                        'statistics' => [[
+                                            'attribs' => ['' => ['views' => '12345']],
+                                        ]],
+                                    ],
+                                ],
+                            ]],
+                        ],
+                    ],
+                ]];
+            }
+        };
+
+        $mockFeed = new class ($mockItem) {
+            private $item;
+
+            public function __construct($item)
+            {
+                $this->item = $item;
+            }
+
+            public function get_items($start = 0, $end = 0): array
+            {
+                return [$this->item];
+            }
+        };
+
+        $result = $model->parseChannel($mockFeed);
+        $this->assertSame(0, $result);
+    }
+
+    public function testParseChannelSkipsPlaysUpdateWithoutStatistics(): void
+    {
+        // Items without media statistics must not trigger a plays update
+        $mockAggro = $this->createMock(AggroModels::class);
+        $mockAggro->method('checkVideo')->willReturn(true);
+        $mockAggro->expects($this->never())->method('setVideoPlays');
+
+        $mockUtility = $this->createMock(UtilityModels::class);
+
+        $model = new YoutubeModels($mockAggro, $mockUtility);
+
+        $mockItem = new class () {
+            public function get_item_tags($namespace, $tag): array
+            {
+                return [['data' => 'existing_video_id']];
+            }
+        };
+
+        $mockFeed = new class ($mockItem) {
+            private $item;
+
+            public function __construct($item)
+            {
+                $this->item = $item;
+            }
+
+            public function get_items($start = 0, $end = 0): array
+            {
+                return [$this->item];
             }
         };
 


### PR DESCRIPTION
## Purpose

Play counts are captured once when a video is added and never touched again, so `video_plays` records views within minutes of upload rather than actual popularity — and archived videos freeze forever. This adds a slow background refresher that cycles the whole table using only public URLs (no API keys), keeping the app's zero-credential design.

## Design

**Two refresh paths:**

1. **Slow crawler** (`PlaysService`, `/aggro/plays`, cron every 15 minutes): processes a small batch (default 10) ordered by `plays_date_updated` oldest-first, NULLs leading, so never-refreshed videos go first and the whole table — including archived videos — cycles over time (~960/day at defaults). Requests are spaced 1s apart.
   - YouTube: scrapes `viewCount` from the watch page, the same page and pattern `getDuration()` already uses for `lengthSeconds`
   - Vimeo: public Simple API per-video endpoint (`vimeo.com/api/v2/video/{id}.json`)
2. **Feed piggyback**: channel feeds already carry current play counts for their ~15 newest videos; `parseChannel()` now updates existing videos from that data instead of discarding it, keeping pre-archive videos fresh at zero extra requests.

**Safety rules:**

- A zero or failed fetch never overwrites a stored count; the refresh date is stamped regardless so the batch cursor advances
- Vimeo owners can hide stats — treated as checked-but-unavailable, not a failure
- Repeated fetch failures (404s, deleted/private videos) increment `plays_issue_count`; past the threshold the video is flagged `flag_bad`, mirroring the thumbnail issue pattern

**Schema:** adds `plays_date_updated`, `plays_issue_count`, and index `idx_video_plays_refresh (flag_bad, plays_date_updated)` via migration; `aggro-db.sql` and the test schema are updated to match.

## Testing

- 20 new tests (TDD): batch ordering and exclusions, all update rules, issue counting and bad-flag threshold, feed piggyback for both platforms, endpoint gating — full suite 584 tests green, lint (php-cs-fixer, phpcs, phpmd, phpstan) clean
- Verified live in dev against real endpoints:
  - Archived YouTube video refreshed 100 → 1,790,392,444 plays via watch-page scrape
  - Vimeo video with public stats refreshed 100 → 78,951,612; hidden-stats video stamped without overwrite
  - Feed piggyback updated an existing video 1 → 18,640 plays during a normal `/aggro/youtube` run while adding 14 new videos

## Deployment notes

- Run `php spark migrate` on deploy
- `.crontab` gains `*/15 * * * * $PHP_PATH $INDEX_PATH aggro plays`
- Pace is tunable via `playsBatchSize` / `playsRequestDelay` in `Config\Storage`