### PR TITLE
Block access to dotfiles in public .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,6 +1,10 @@
 # Disable directory browsing
 Options All -Indexes
 
+# Return 404 for dotfiles and dot-directories (.env, .git, etc.),
+# except .well-known (ACME/security.txt)
+RedirectMatch 404 "/\.(?!well-known/)"
+
 # Add webp and avif image format support
 AddType image/webp .webp
 AddType image/avif .avif


### PR DESCRIPTION
## Summary

Server error logs show automated scanners regularly probing for `/.env`, `/.env.backup`, `/.git/config`, and similar paths. These requests were already denied, but only by DreamHost's server-level configuration — nothing in this repo blocks them. This adds a `RedirectMatch` rule to `public/.htaccess` so dotfile requests return 404 regardless of host configuration.

- Returns 404 instead of 403, so scanners get no confirmation the path is meaningful and the probes stop landing in the error log
- Excludes `/.well-known/` to preserve ACME challenges and `security.txt`
- Defense in depth: the real `.env` already lives above the docroot and `deploy.php` excludes `.env*` from rsync

## Testing

Verified against DDEV:

- `/.env`, `/.env.backup`, `/.env.production`, `/.git/config` → 404, served by Apache's mod_alias (not the CodeIgniter 404 fallback)
- A test file in `/.well-known/` → 200
- Homepage → 200
- Full PHPUnit suite passes (584 tests, 1043 assertions, 34 pre-existing skips)

After the next deploy, spot-check that `https://bmxfeed.com/.env` returns 404 and new probes appear in the access log rather than the error log.