### PR TITLE
Fix play count refresh Sentry errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,16 @@ ddev deploy dev
 ddev deploy prod
 ```
 
+### Database migrations
+
+Deployments intentionally do not run database migrations (see the `deploy` task list in `deploy.php`). When a release includes new migrations, SSH to the server and run them from the current release directory:
+
+```bash
+php spark migrate
+```
+
+Because deployment to production happens automatically on merge to main, run migrations immediately after merging a PR that includes them — new code that depends on the schema change will error until the migration runs.
+
 ## Error monitoring
 
 Aggro uses Sentry for application monitoring:

--- a/app/Helpers/aggro_helper.php
+++ b/app/Helpers/aggro_helper.php
@@ -303,7 +303,9 @@ if (! function_exists('fetch_url')) {
 
         if ($httpCode === 403 || $httpCode === 404 || $httpCode === 500) {
             $message = $url . ' returned ' . $httpCode . '.';
-            log_message('error', $message);
+            // A 404 means the content is gone, not an application error,
+            // so it stays out of Sentry (which only receives error and above).
+            log_message($httpCode === 404 ? 'warning' : 'error', $message);
 
             return false;
         }

--- a/app/Helpers/aggro_helper.php
+++ b/app/Helpers/aggro_helper.php
@@ -301,11 +301,13 @@ if (! function_exists('fetch_url')) {
         $errorInfo  = curl_error($fetch);
         curl_close($fetch);
 
-        if ($httpCode === 403 || $httpCode === 404 || $httpCode === 500) {
+        // A 404 means the content is gone, not an application error,
+        // so it stays out of Sentry (which only receives error and above).
+        $failureLogLevels = [403 => 'error', 404 => 'warning', 500 => 'error'];
+
+        if (isset($failureLogLevels[$httpCode])) {
             $message = $url . ' returned ' . $httpCode . '.';
-            // A 404 means the content is gone, not an application error,
-            // so it stays out of Sentry (which only receives error and above).
-            log_message($httpCode === 404 ? 'warning' : 'error', $message);
+            log_message($failureLogLevels[$httpCode], $message);
 
             return false;
         }

--- a/app/Helpers/vimeo_helper.php
+++ b/app/Helpers/vimeo_helper.php
@@ -40,18 +40,22 @@ if (! function_exists('vimeo_get_plays')) {
     /**
      * Fetch Vimeo video play count.
      *
-     * @param string $videoID
-     *                        Vimeo videoID.
+     * @param string   $videoID
+     *                              Vimeo videoID.
+     * @param int|null &$httpStatus
+     *                              Optional. Populated with the HTTP response code.
+     *
+     * @param-out int $httpStatus
      *
      * @return false|string|null
      *                           Play count, null when the owner hides stats, or false on error.
      */
-    function vimeo_get_plays($videoID)
+    function vimeo_get_plays($videoID, &$httpStatus = null)
     {
         helper('aggro');
 
         $fetch  = 'https://vimeo.com/api/v2/video/' . $videoID . '.json';
-        $result = fetch_url($fetch, 'json', 0);
+        $result = fetch_url($fetch, 'json', 0, $httpStatus);
 
         if ($result === false || ! is_array($result) || ! isset($result[0]) || ! is_object($result[0])) {
             return false;

--- a/app/Helpers/youtube_helper.php
+++ b/app/Helpers/youtube_helper.php
@@ -37,18 +37,22 @@ if (! function_exists('youtube_get_plays')) {
     /**
      * Fetch YouTube video play count.
      *
-     * @param string $videoID
-     *                        YouTube videoID.
+     * @param string   $videoID
+     *                              YouTube videoID.
+     * @param int|null &$httpStatus
+     *                              Optional. Populated with the HTTP response code.
+     *
+     * @param-out int $httpStatus
      *
      * @return false|string
      *                      Play count, or false on error.
      */
-    function youtube_get_plays($videoID)
+    function youtube_get_plays($videoID, &$httpStatus = null)
     {
         helper('aggro');
 
         $videoPage  = 'https://www.youtube.com/watch?v=' . $videoID;
-        $resultPage = fetch_url($videoPage, 'text', 0);
+        $resultPage = fetch_url($videoPage, 'text', 0, $httpStatus);
 
         if ($resultPage !== false && is_string($resultPage)) {
             if (preg_match('/"viewCount":"(\d+)"/', $resultPage, $matches)) {

--- a/app/Repositories/VideoRepository.php
+++ b/app/Repositories/VideoRepository.php
@@ -379,6 +379,27 @@ class VideoRepository
     }
 
     /**
+     * Flag a video as bad immediately.
+     *
+     * Used when a source confirms the video is permanently gone, so it
+     * skips the failure-count threshold entirely.
+     *
+     * @param string $videoId
+     *                        Video id.
+     *
+     * @return bool
+     *              Video flagged bad.
+     */
+    public function flagVideoBad($videoId)
+    {
+        $this->db->table('aggro_videos')
+            ->where('video_id', $videoId)
+            ->update(['flag_bad' => 1]);
+
+        return $this->db->affectedRows() > 0;
+    }
+
+    /**
      * Get single video.
      *
      * @param string $slug

--- a/app/Repositories/VideoRepository.php
+++ b/app/Repositories/VideoRepository.php
@@ -279,6 +279,12 @@ class VideoRepository
             ->limit((int) $limit)
             ->get();
 
+        if ($query === false) {
+            log_message('error', 'Play count refresh query failed.');
+
+            return [];
+        }
+
         return $query->getResult();
     }
 

--- a/app/Services/PlaysService.php
+++ b/app/Services/PlaysService.php
@@ -44,9 +44,17 @@ class PlaysService
                 sleep($storageConfig->playsRequestDelay);
             }
 
-            $plays = $this->fetchPlays($video);
+            $httpStatus = null;
+            $plays      = $this->fetchPlays($video, $httpStatus);
 
             if ($plays === false) {
+                if ($httpStatus === 404) {
+                    $this->videoRepository->flagVideoBad($video->video_id);
+                    log_message('warning', 'Flagged video ' . $video->video_id . ' as bad — source returned 404.');
+
+                    continue;
+                }
+
                 $this->videoRepository->recordPlaysIssue($video->video_id);
 
                 continue;
@@ -72,19 +80,23 @@ class PlaysService
     /**
      * Fetch the current play count for a video from its public endpoint.
      *
-     * @param object $video
-     *                      Row with video_id and video_type.
+     * @param object   $video
+     *                              Row with video_id and video_type.
+     * @param int|null &$httpStatus
+     *                              Optional. Populated with the HTTP response code.
+     *
+     * @param-out int $httpStatus
      *
      * @return false|int|null
      *                        Play count, null when the source hides stats, or false on fetch failure.
      */
-    protected function fetchPlays(object $video)
+    protected function fetchPlays(object $video, ?int &$httpStatus = null)
     {
         if ($video->video_type === 'vimeo') {
-            return $this->normalizePlays(vimeo_get_plays($video->video_id));
+            return $this->normalizePlays(vimeo_get_plays($video->video_id, $httpStatus));
         }
 
-        return $this->normalizePlays(youtube_get_plays($video->video_id));
+        return $this->normalizePlays(youtube_get_plays($video->video_id, $httpStatus));
     }
 
     /**

--- a/tests/unit/AggroHelperTest.php
+++ b/tests/unit/AggroHelperTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\TestLogger;
 use ReflectionFunction;
 use TypeError;
 
@@ -366,6 +367,15 @@ final class AggroHelperTest extends CIUnitTestCase
         fetch_url('https://httpbin.org/status/404', 'text', 0, $httpStatus);
 
         $this->assertSame(404, $httpStatus);
+    }
+
+    public function testFetchUrl404LogsWarningNotError(): void
+    {
+        $result = fetch_url('https://httpbin.org/status/404', 'text', 0);
+
+        $this->assertFalse($result);
+        $this->assertLogged('warning', 'https://httpbin.org/status/404 returned 404.');
+        $this->assertFalse(TestLogger::didLog('error', 'https://httpbin.org/status/404 returned 404.'));
     }
 
     public function testFetchThumbnailPassesThroughHttpStatus(): void

--- a/tests/unit/PlaysServiceTest.php
+++ b/tests/unit/PlaysServiceTest.php
@@ -44,9 +44,12 @@ final class PlaysServiceTest extends ServiceTestCase
     {
         return new class (null, $utilityModel) extends PlaysService {
             public array $responses = [];
+            public array $statuses  = [];
 
-            protected function fetchPlays(object $video)
+            protected function fetchPlays(object $video, ?int &$httpStatus = null)
             {
+                $httpStatus = $this->statuses[$video->video_id] ?? 200;
+
                 if (! array_key_exists($video->video_id, $this->responses)) {
                     return false;
                 }
@@ -164,6 +167,48 @@ final class PlaysServiceTest extends ServiceTestCase
         $this->assertSame(1, (int) $row['plays_issue_count']);
         $this->assertNotNull($row['plays_date_updated']);
         $this->assertSame(0, (int) $row['flag_bad']);
+    }
+
+    public function testRefreshPlaysFlagsBadImmediatelyOn404()
+    {
+        // Arrange
+        $this->insertTestVideo($this->makeVideo([
+            'video_id'    => 'deleted_video',
+            'video_plays' => 900,
+        ]));
+
+        $this->service->responses = ['deleted_video' => false];
+        $this->service->statuses  = ['deleted_video' => 404];
+
+        // Act
+        $this->service->refreshPlays();
+
+        // Assert - Flagged bad on first 404, threshold path not taken
+        $row = $this->getVideoRow('deleted_video');
+        $this->assertSame(1, (int) $row['flag_bad']);
+        $this->assertSame(0, (int) $row['plays_issue_count']);
+        $this->assertSame(900, (int) $row['video_plays']);
+        $this->assertLogged('warning', 'Flagged video deleted_video as bad — source returned 404.');
+    }
+
+    public function testRefreshPlaysRecordsIssueOnTransientFailure()
+    {
+        // Arrange
+        $this->insertTestVideo($this->makeVideo([
+            'video_id'    => 'flaky_video',
+            'video_plays' => 900,
+        ]));
+
+        $this->service->responses = ['flaky_video' => false];
+        $this->service->statuses  = ['flaky_video' => 500];
+
+        // Act
+        $this->service->refreshPlays();
+
+        // Assert - Transient failure keeps the threshold path
+        $row = $this->getVideoRow('flaky_video');
+        $this->assertSame(0, (int) $row['flag_bad']);
+        $this->assertSame(1, (int) $row['plays_issue_count']);
     }
 
     public function testRefreshPlaysDoesNotOverwriteWithZero()

--- a/tests/unit/VideoRepositoryTest.php
+++ b/tests/unit/VideoRepositoryTest.php
@@ -260,6 +260,30 @@ final class VideoRepositoryTest extends RepositoryTestCase
         $this->assertSame([], $results);
     }
 
+    public function testFlagVideoBadSetsFlagImmediately()
+    {
+        // Arrange
+        $videoData = $this->createTestVideo(['video_id' => 'gone_404']);
+        $this->db->table('aggro_videos')->insert($videoData);
+
+        // Act
+        $result = $this->repository->flagVideoBad('gone_404');
+
+        // Assert
+        $this->assertTrue($result);
+        $row = $this->db->table('aggro_videos')->where('video_id', 'gone_404')->get()->getRowArray();
+        $this->assertSame(1, (int) $row['flag_bad']);
+    }
+
+    public function testFlagVideoBadReturnsFalseForNonExistentVideo()
+    {
+        // Act
+        $result = $this->repository->flagVideoBad('non_existent_video');
+
+        // Assert
+        $this->assertFalse($result);
+    }
+
     public function testUpdateVideoPlaysWritesCountAndResetsIssues()
     {
         // Arrange

--- a/tests/unit/VideoRepositoryTest.php
+++ b/tests/unit/VideoRepositoryTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Repositories\VideoRepository;
+use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\BaseConnection;
 use Tests\Support\RepositoryTestCase;
 
 /**
@@ -233,6 +235,29 @@ final class VideoRepositoryTest extends RepositoryTestCase
         // Assert
         $this->assertCount(1, $results);
         $this->assertSame('archived_video', $results[0]->video_id);
+    }
+
+    public function testGetVideosForPlaysRefreshReturnsEmptyArrayWhenQueryFails()
+    {
+        // Arrange - Force the query builder's get() to fail like a DB error
+        $builder = $this->createMock(BaseBuilder::class);
+        $builder->method('select')->willReturnSelf();
+        $builder->method('where')->willReturnSelf();
+        $builder->method('orderBy')->willReturnSelf();
+        $builder->method('limit')->willReturnSelf();
+        $builder->method('get')->willReturn(false);
+
+        $connection = $this->createMock(BaseConnection::class);
+        $connection->method('table')->willReturn($builder);
+
+        $repository = new VideoRepository();
+        $this->setPrivateProperty($repository, 'db', $connection);
+
+        // Act
+        $results = $repository->getVideosForPlaysRefresh(10);
+
+        // Assert
+        $this->assertSame([], $results);
     }
 
     public function testUpdateVideoPlaysWritesCountAndResetsIssues()

--- a/tests/unit/VimeoHelperTest.php
+++ b/tests/unit/VimeoHelperTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use ReflectionFunction;
 
 /**
  * @internal
@@ -32,6 +33,16 @@ final class VimeoHelperTest extends CIUnitTestCase
     {
         $result = vimeo_get_feed('');
         $this->assertFalse($result);
+    }
+
+    public function testVimeoGetPlaysAcceptsHttpStatusOutParam(): void
+    {
+        $params = (new ReflectionFunction('vimeo_get_plays'))->getParameters();
+
+        $this->assertCount(2, $params);
+        $this->assertSame('httpStatus', $params[1]->getName());
+        $this->assertTrue($params[1]->isPassedByReference());
+        $this->assertTrue($params[1]->isOptional());
     }
 
     public function testVimeoIdFromUrlMethodExists(): void

--- a/tests/unit/YoutubeHelperTest.php
+++ b/tests/unit/YoutubeHelperTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use ReflectionFunction;
 
 /**
  * @internal
@@ -13,6 +14,16 @@ final class YoutubeHelperTest extends CIUnitTestCase
     {
         parent::setUp();
         helper('youtube');
+    }
+
+    public function testYoutubeGetPlaysAcceptsHttpStatusOutParam(): void
+    {
+        $params = (new ReflectionFunction('youtube_get_plays'))->getParameters();
+
+        $this->assertCount(2, $params);
+        $this->assertSame('httpStatus', $params[1]->getName());
+        $this->assertTrue($params[1]->isPassedByReference());
+        $this->assertTrue($params[1]->isOptional());
     }
 
     public function testYoutubeGetDurationMethodExists(): void


### PR DESCRIPTION
## Description

Resolves all five Sentry issues from this week, each traceable to the play count refresh feature (#810):

- **AGGRO-23** (1,462 events, ongoing): the refresh sweep logs an error-level Sentry event for every deleted Vimeo video it finds (~400/day during the first archive pass), and a permanently gone video needed 11 failed fetches — one per full table cycle — before being flagged bad.
- **AGGRO-20**: `getVideosForPlaysRefresh()` called `getResult()` on `false` when the query failed during the release 366 deploy window.
- **AGGRO-1Z/21/22**: release 366 code went live before its migration ran; deploys intentionally don't run migrations, but that step wasn't documented.

Changes, each test-first:

1. Guard `getVideosForPlaysRefresh()` against a failed query — log and return an empty array (matches the `videoExists()` pattern).
2. Log 404 fetches at `warning` instead of `error` in `fetch_url()`, so expected content-gone responses stay in file logs without reaching Sentry. 403/500 stay at `error`.
3. Flag videos bad on the first 404 during plays refresh. The HTTP status threads through `vimeo_get_plays()`/`youtube_get_plays()` as an optional out-param (mirroring the `fetch_thumbnail` pattern). Transient failures keep the existing `plays_issue_count` threshold path.
4. Document the manual `php spark migrate` step in the README deployment section.

Fixes AGGRO-23
Fixes AGGRO-20

## Type of Change
- [x] 🐛 Bug fix
- [x] 📝 Documentation

## Testing
- [x] Local development environment (`composer test`: 592 tests green; `composer lint` clean)
- [x] CI/CD passes

New tests: DB-failure guard (mocked connection), 404 log level, `flagVideoBad()`, helper out-param signatures, first-404 fast-flag, and transient-failure threshold boundary.

## Additional Notes

- The 404 log-level change affects **all** `fetch_url` callers (feeds, thumbnails), not just plays — a net Sentry noise reduction, consistent with treating 404 as content-gone rather than an application error.
- YouTube rarely returns HTTP 404 for deleted videos (typically 200 with no `viewCount`), so the first-404 fast-flag fires almost exclusively for Vimeo. YouTube dead videos still age out via the threshold path. Intended.
- A chronic non-404 failure still reaches Sentry via the over-threshold error log in `recordPlaysIssue()` — kept deliberately as a signal.
- After merge: AGGRO-1Z/21/22 should be resolved manually in Sentry (deploy-window schema errors; migration already ran).